### PR TITLE
fix: rename vaults to treasuries

### DIFF
--- a/contracts/treasury/ERC20Treasury.sol
+++ b/contracts/treasury/ERC20Treasury.sol
@@ -10,11 +10,10 @@ import "../interfaces/ERC20WithdrawStrategy.sol";
  *
  * @dev
  */
-contract ERC20Vault is Context {
-
+contract ERC20Treasury is Context {
     ERC20DepositStrategy private _depositStrategy;
     ERC20WithdrawStrategy private _withdrawStrategy;
-    mapping (string => address) private _tokens;
+    mapping(string => address) private _tokens;
 
     constructor(ERC20DepositStrategy deposit, ERC20WithdrawStrategy withdraw) {
         _depositStrategy = deposit;
@@ -27,18 +26,22 @@ contract ERC20Vault is Context {
         //TODO get the abbreviation from the token & put into _tokens
     }
 
-    function depositERC20(uint256 amount, string calldata tokenAbbreviation) public {
+    function depositERC20(uint256 amount, string calldata tokenAbbreviation)
+        public
+    {
         //TODO require the token to be one that is being stored
-
         //TODO either approve & transferFrom or Orcale sends in notifications on transfer events
         //TODO emit transfer in event
-
         // Before this you should have approved the amount
         // This will transfer the amount of  _token from caller to contract
-         //   IERC20(_token).transferFrom(msg.sender, address(this), amount);
+        //   IERC20(_token).transferFrom(msg.sender, address(this), amount);
     }
 
-    function withdrawERC20(address destination, string calldata tokenAbbreviation, uint256 amount) public {
+    function withdrawERC20(
+        address destination,
+        string calldata tokenAbbreviation,
+        uint256 amount
+    ) public {
         //TODO check balance, maybe do that elsewhere or delegate to token contract?
         //TODO contact the ERC20 contract and transfer
         //TODO emit transfer out event

--- a/contracts/treasury/ERC721Treasury.sol
+++ b/contracts/treasury/ERC721Treasury.sol
@@ -12,14 +12,14 @@ import "../interfaces/ERC721WithdrawStrategy.sol";
  *
  * @dev
  */
-contract ERC721Vault is Context, IERC721Receiver {
+contract ERC721Treasury is Context, IERC721Receiver {
+    ERC721DepositStrategy private _depositStrategy;
+    ERC721WithdrawStrategy private _withdrawStrategy;
 
-ERC721DepositStrategy private _depositStrategy;
-ERC721WithdrawStrategy private _withdrawStrategy;
-
-    constructor(ERC721DepositStrategy deposit, ERC721WithdrawStrategy withdraw) {
-    _depositStrategy = deposit;
-    _withdrawStrategy = withdraw;
+    constructor(ERC721DepositStrategy deposit, ERC721WithdrawStrategy withdraw)
+    {
+        _depositStrategy = deposit;
+        _withdrawStrategy = withdraw;
     }
 
     function onERC721Received(
@@ -27,7 +27,7 @@ ERC721WithdrawStrategy private _withdrawStrategy;
         address from,
         uint256 tokenId,
         bytes calldata data
-    ) external override returns (bytes4){
+    ) external override returns (bytes4) {
         //TODO require on input parameters to reject certain (non-whitelisted tokens)
 
         //TODO invoke despositERC721()
@@ -35,7 +35,9 @@ ERC721WithdrawStrategy private _withdrawStrategy;
         return IERC721Receiver.onERC721Received.selector;
     }
 
-    function doSomethingWith721Token(IERC721 nftAddress, uint256 tokenId) external {
+    function doSomethingWith721Token(IERC721 nftAddress, uint256 tokenId)
+        external
+    {
         // do something here
     }
 

--- a/contracts/treasury/ETHTreasury.sol
+++ b/contracts/treasury/ETHTreasury.sol
@@ -10,7 +10,7 @@ import "../interfaces/ETHWithdrawStrategy.sol";
  *
  * @dev
  */
-contract ETHVault is Context {
+contract ETHTreasury is Context {
     ETHDepositStrategy private _depositStrategy;
     ETHWithdrawStrategy private _withdrawStrategy;
 

--- a/contracts/treasury/Treasury.sol
+++ b/contracts/treasury/Treasury.sol
@@ -2,16 +2,26 @@
 pragma solidity ^0.8.0;
 
 import "@openzeppelin/contracts/utils/Context.sol";
-import "./ETHVault.sol";
-import "./ERC20Vault.sol";
-import "./ERC721Vault.sol";
+import "./ETHTreasury.sol";
+import "./ERC20Treasury.sol";
+import "./ERC721Treasury.sol";
 
 /**
  * @title Treasury is where the valuables are kept.
  *
  * @dev
  */
-contract Treasury is Context, ETHVault, ERC20Vault, ERC721Vault {
-
-    constructor(ETHDepositStrategy depositETH, ETHWithdrawStrategy withdrawETH, ERC20DepositStrategy depositERC20, ERC20WithdrawStrategy withdrawERC20, ERC721DepositStrategy depositERC721, ERC721WithdrawStrategy withdrawERC721) ETHVault(depositETH,withdrawETH) ERC20Vault(depositERC20,withdrawERC20) ERC721Vault(depositERC721, withdrawERC721) {}
+contract Treasury is Context, ETHTreasury, ERC20Treasury, ERC721Treasury {
+    constructor(
+        ETHDepositStrategy depositETH,
+        ETHWithdrawStrategy withdrawETH,
+        ERC20DepositStrategy depositERC20,
+        ERC20WithdrawStrategy withdrawERC20,
+        ERC721DepositStrategy depositERC721,
+        ERC721WithdrawStrategy withdrawERC721
+    )
+        ETHTreasury(depositETH, withdrawETH)
+        ERC20Treasury(depositERC20, withdrawERC20)
+        ERC721Treasury(depositERC721, withdrawERC721)
+    {}
 }


### PR DESCRIPTION
### Purpose for this PR
The term `Vault` is overloaded, within the context of money management `Treasury` is better suited.
<!-- Have you included adequate testing for this change? -->
