### PR TITLE
feat: emit event when full collateral has been reached

### DIFF
--- a/contracts/bond/Bond.sol
+++ b/contracts/bond/Bond.sol
@@ -14,13 +14,13 @@ import "@openzeppelin/contracts/security/Pausable.sol";
  */
 contract Bond is Context, ERC20, Ownable, Pausable {
     event AllowRedemption(address authorizer);
-    event WithdrawCollateral(address receiver, string symbol, uint256 amount);
     event DebtIssue(address receiver, string debSymbol, uint256 debtAmount);
     event Deposit(
         address depositor,
         string collateralSymbol,
         uint256 collateralAmount
     );
+    event FullCollateral(string collateralSymbol, uint256 collateralAmount);
     event Redemption(
         address redeemer,
         string debtSymbol,
@@ -29,6 +29,7 @@ contract Bond is Context, ERC20, Ownable, Pausable {
         uint256 collateralAmount
     );
     event Slash(string collateralSymbol, uint256 collateralAmount);
+    event WithdrawCollateral(address receiver, string symbol, uint256 amount);
 
     /**
      * @dev Modifier to make a function callable only when the contract is not redeemable.
@@ -120,6 +121,13 @@ contract Bond is Context, ERC20, Ownable, Pausable {
 
         _transfer(address(this), sender, amount);
         emit DebtIssue(sender, symbol(), amount);
+
+        if (balanceOf(address(this)) == 0) {
+            emit FullCollateral(
+                _collateralToken.symbol(),
+                _collateralToken.balanceOf(address(this))
+            );
+        }
     }
 
     /**

--- a/docs/specs/bonding.puml
+++ b/docs/specs/bonding.puml
@@ -60,6 +60,8 @@ end
 note left of bond           : Bond balance 150K BIT
 note left of guarantor      : Guarantors hold 150K debt certificates
 
+bond --> alice              : Bond collateral met
+
 == Grants Treasury Funding ==
 alice -> snapshot               : submit proposal
 snapshot-->community            : new proposal notification

--- a/test/bond.test.ts
+++ b/test/bond.test.ts
@@ -25,7 +25,8 @@ import {
     verifySlashEvent,
     verifyTransferEvent,
     verifyAllowRedemptionEvent,
-    verifyWithdrawCollateralEvent
+    verifyWithdrawCollateralEvent,
+    verifyFullCollateralEvent
 } from './utils/events'
 import {SignerWithAddress} from '@nomiclabs/hardhat-ethers/signers'
 import {successfulTransaction} from './utils/transaction'
@@ -435,6 +436,7 @@ describe('Bond contract', () => {
     it('one guarantor deposit, then is fully slashed', async () => {
         const pledge = 40050n
         const debtTokens = pledge
+        const collateralAmount = debtTokens
         const slashedCollateral = debtTokens
         bond = await createBond(factory, debtTokens)
         const debtSymbol = await bond.symbol()
@@ -454,6 +456,10 @@ describe('Bond contract', () => {
         await verifyDebtIssueEvent(depositOne, guarantorOne.address, {
             symbol: debtSymbol,
             amount: pledge
+        })
+        await verifyFullCollateralEvent(depositOne, {
+            symbol: collateralSymbol,
+            amount: collateralAmount
         })
 
         // Bond holds all collateral, issued debt tokens
@@ -507,6 +513,7 @@ describe('Bond contract', () => {
         const pledgeOne = 240050n
         const pledgeTwo = 99500n
         const debtTokens = pledgeOne + pledgeTwo
+        const collateralAmount = debtTokens
         bond = await createBond(factory, debtTokens)
         const debtSymbol = await bond.symbol()
         await setupGuarantorsWithCollateral([
@@ -534,6 +541,10 @@ describe('Bond contract', () => {
         await verifyDebtIssueEvent(depositTwo, guarantorTwo.address, {
             symbol: debtSymbol,
             amount: pledgeTwo
+        })
+        await verifyFullCollateralEvent(depositTwo, {
+            symbol: collateralSymbol,
+            amount: collateralAmount
         })
 
         // Bond holds all collateral, issued debt tokens

--- a/test/utils/events.ts
+++ b/test/utils/events.ts
@@ -4,6 +4,7 @@ import {BondCreatedEvent} from '../../typechain/BondFactory'
 import {
     AllowRedemptionEvent,
     DebtIssueEvent,
+    FullCollateralEvent,
     RedemptionEvent,
     SlashEvent,
     WithdrawCollateralEvent
@@ -116,6 +117,23 @@ export function events(receipt: ContractReceipt): Event[] {
 }
 
 /**
+ * Shape check and conversion for a FullCollateralEvent.
+ */
+export function fullCollateralEvent(event: Event): {
+    collateralSymbol: string
+    collateralAmount: BigNumber
+} {
+    const collateral = event as FullCollateralEvent
+    expect(event.args).is.not.undefined
+
+    const args = event.args
+    expect(args?.collateralSymbol).is.not.undefined
+    expect(args?.collateralAmount).is.not.undefined
+
+    return collateral.args
+}
+
+/**
  * Shape check and conversion for a RedemptionEvent.
  */
 export function redemptionEvent(event: Event): {
@@ -186,6 +204,24 @@ export async function verifyAllowRedemptionEvent(
     )
     expect(allowRedemption.authorizer, 'AllowRedemption authorizer').equals(
         authorizer
+    )
+}
+
+/**
+ * Verifies the content for a Full Collateral event.
+ */
+export async function verifyFullCollateralEvent(
+    receipt: ContractReceipt,
+    collateral: ExpectTokenBalance
+): Promise<void> {
+    const fullCollateral = fullCollateralEvent(
+        event('FullCollateral', events(receipt))
+    )
+    expect(fullCollateral.collateralSymbol, 'Debt token symbol').equals(
+        collateral.symbol
+    )
+    expect(fullCollateral.collateralAmount, 'Debt token amount').equals(
+        collateral.amount
     )
 }
 


### PR DESCRIPTION
### Purpose for this PR

<!-- Have you included adequate testing for this change? -->
The only option available for Alice to know when her bond has reach full collateralization is by polling.

This PR adds an event that is emitted when the final deposit is made, reaching full collateral.