### PR TITLE
feat: render PlantUML as SVG

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -5,6 +5,9 @@ cache
 # TypeChain
 typechain
 
+# PlantUML images
+docs/specs/images
+
 # Logs
 logs
 *.log

--- a/.gitignore
+++ b/.gitignore
@@ -85,3 +85,6 @@ doc/
 
 # Node lock file
 package-lock.json
+
+# MacOS system files
+.DS_Store

--- a/.gitignore
+++ b/.gitignore
@@ -5,9 +5,6 @@ cache
 # TypeChain
 typechain
 
-# PlantUML images
-docs/specs/images
-
 # Logs
 logs
 *.log

--- a/.lintstagedrc
+++ b/.lintstagedrc
@@ -1,5 +1,5 @@
 {
-    "*.(md|js|json)": "npm run format",
+    "*.(md|mjs|js|json)": "npm run format",
     "*.sol": "npm run format",
     "*.ts":  "npm run lint -- --fix"
 }

--- a/.prettierrc
+++ b/.prettierrc
@@ -2,6 +2,17 @@
   "$schema": "http://json.schemastore.org/prettierrc",
   "overrides": [
     {
+      "files": "*.sol || *.mjs",
+      "options": {
+        "bracketSpacing": false,
+        "explicitTypes": "always",
+        "printWidth": 80,
+        "singleQuote": false,
+        "tabWidth": 4,
+        "useTabs": false
+      }
+    },
+    {
       "files": "*.ts",
       "options": {
         "arrowParens": "always",
@@ -12,17 +23,6 @@
         "singleQuote": true,
         "tabWidth": 4,
         "trailingComma": "none"
-      }
-    },
-    {
-      "files": "*.sol",
-      "options": {
-        "bracketSpacing": false,
-        "explicitTypes": "always",
-        "printWidth": 80,
-        "singleQuote": false,
-        "tabWidth": 4,
-        "useTabs": false
       }
     }
   ]

--- a/README.md
+++ b/README.md
@@ -1,19 +1,23 @@
 # WindRanger Treasury
+
 Inbound and outbound treasury
 
-
 ## Development Process
+
 Development follows these processes outlined in [development process](docs/development_process.md)
 
 ## Setup
 
 ### Install
+
 To retrieve the project dependencies and before any further tasks will run correctly
+
 ```shell
 npm install
 ```
 
 #### Husky Git Commit Hooks
+
 To enable Husky commit hooks to trigger the lint-staged behaviour of formatting and linting the staged files prior
 before committing, prepare your repo with `prepare`.
 
@@ -22,45 +26,74 @@ npm run prepare
 ```
 
 #### Build and Test
+
 ```shell
 npm run build
 npm test
 ```
 
 If you make changes that don't get picked up then add a clean into the process
+
 ```shell
 npm run clean
 npm run build
 npm test
 ```
 
-
 ### Hardhat
+
 If you want to avoid using the convience scripts, then you can execute against Hardhat directly.
 
 #### All tests
-Target to run all the mocha tests found in the ```/test``` directory, transpiled as necessary.
+
+Target to run all the mocha tests found in the `/test` directory, transpiled as necessary.
+
 ```shell
 npx hardhat test
 ```
 
 #### Single test
+
 Run a single test (or a regex of tests), then pass in as an argument.
+
 ```shell
  npx hardhat test .\test\sample.test.ts
 ```
 
 #### Scripts
+
 The TypeScript transpiler will automatically as needed, execute through HardHat for the instantiated environment
+
 ```shell
 npx hardhat run .\scripts\sample-script.ts
 ```
 
 ### Logging
+
 Logging is performed with Bunyan
 
 #### Bunyan CLI
+
 To have the JSON logging output into a more human-readable form, pipe the stdout to the Bunyan CLI tool.
+
 ```shell
 npx hardhat accounts | npx bunyan
+```
+
+## Sequence Diagram Rendering
+
+To create or update the renders for the Plant UML sequence diagrams
+
+#### Ensure Java is installed
+
+```shell
+java -version
+```
+
+The output will vary depending on OS, however if it fails claiming Java is not found, then you must install before proceeding.
+
+#### Generate renders for all Plant UML documents under `docs/spec`
+
+```shell
+npm run plant
 ```

--- a/docs/specs/images/bonding-0.svg
+++ b/docs/specs/images/bonding-0.svg
@@ -1,0 +1,266 @@
+<?xml version="1.0" encoding="UTF-8" standalone="no"?><svg xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink" contentScriptType="application/ecmascript" contentStyleType="text/css" height="2433px" preserveAspectRatio="none" style="width:1498px;height:2433px;background:#FFFFFF;" version="1.1" viewBox="0 0 1498 2433" width="1498px" zoomAndPan="magnify"><defs><filter height="300%" id="f1d4shlhj7bai8" width="300%" x="-1" y="-1"><feGaussianBlur result="blurOut" stdDeviation="2.0"/><feColorMatrix in="blurOut" result="blurOut2" type="matrix" values="0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 .4 0"/><feOffset dx="4.0" dy="4.0" in="blurOut2" result="blurOut3"/><feBlend in="SourceGraphic" in2="blurOut3" mode="normal"/></filter></defs><g><text fill="#000000" font-family="sans-serif" font-size="18" lengthAdjust="spacing" textLength="70" x="710.5" y="29.4023">Bonding</text><rect fill="#FFFFE0" height="2386.6484" style="stroke:#A80036;stroke-width:1.0;" width="92" x="1" y="41.1992"/><text fill="#000000" font-family="sans-serif" font-size="13" font-weight="bold" lengthAdjust="spacing" textLength="86" x="4" y="53.7676">(community)</text><rect fill="#FF7F50" height="2386.6484" style="stroke:#A80036;stroke-width:1.0;" width="71" x="264" y="41.1992"/><text fill="#000000" font-family="sans-serif" font-size="13" font-weight="bold" lengthAdjust="spacing" textLength="65" x="267" y="53.7676">(offchain)</text><rect fill="#D3D3D3" height="2386.6484" style="stroke:#A80036;stroke-width:1.0;" width="179" x="340" y="41.1992"/><text fill="#000000" font-family="sans-serif" font-size="13" font-weight="bold" lengthAdjust="spacing" textLength="86" x="386.5" y="53.7676">(community)</text><rect fill="#FF7F50" height="2386.6484" style="stroke:#A80036;stroke-width:1.0;" width="78" x="532.5" y="41.1992"/><text fill="#000000" font-family="sans-serif" font-size="13" font-weight="bold" lengthAdjust="spacing" textLength="65" x="539" y="53.7676">(offchain)</text><rect fill="#CD853F" height="2386.6484" style="stroke:#A80036;stroke-width:1.0;" width="107" x="656" y="41.1992"/><text fill="#000000" font-family="sans-serif" font-size="13" font-weight="bold" lengthAdjust="spacing" textLength="65" x="677" y="53.7676">(multisig)</text><rect fill="#E6E6FA" height="2386.6484" style="stroke:#A80036;stroke-width:1.0;" width="661" x="814" y="41.1992"/><text fill="#000000" font-family="sans-serif" font-size="13" font-weight="bold" lengthAdjust="spacing" textLength="64" x="1112.5" y="53.7676">(onchain)</text><rect fill="#FFFFFF" filter="url(#f1d4shlhj7bai8)" height="75.9316" style="stroke:#000000;stroke-width:2.0;" width="456" x="429" y="628.3457"/><rect fill="#ADD8E6" filter="url(#f1d4shlhj7bai8)" height="468.3027" style="stroke:#000000;stroke-width:2.0;" width="1062" x="419" y="957.4512"/><rect fill="#FFC0CB" height="284.4395" style="stroke:none;stroke-width:1.0;" width="1062" x="419" y="1141.3145"/><rect fill="#FFFFFF" filter="url(#f1d4shlhj7bai8)" height="75.9316" style="stroke:#000000;stroke-width:2.0;" width="456" x="429" y="1303.5117"/><rect fill="#ADD8E6" filter="url(#f1d4shlhj7bai8)" height="483.2578" style="stroke:#000000;stroke-width:2.0;" width="1062" x="419" y="1801.791"/><rect fill="#FFFFFF" filter="url(#f1d4shlhj7bai8)" height="75.9316" style="stroke:#000000;stroke-width:2.0;" width="456" x="429" y="1897.7227"/><rect fill="#FFC0CB" height="126.8867" style="stroke:none;stroke-width:1.0;" width="1062" x="419" y="1980.6543"/><rect fill="#20B2AA" height="177.5078" style="stroke:none;stroke-width:1.0;" width="1062" x="419" y="2107.541"/><rect fill="#FFFFFF" filter="url(#f1d4shlhj7bai8)" height="75.9316" style="stroke:#000000;stroke-width:2.0;" width="456" x="429" y="2202.1172"/><line style="stroke:#A80036;stroke-width:1.0;stroke-dasharray:5.0,5.0;" x1="46.5" x2="46.5" y1="143.998" y2="2341.3594"/><line style="stroke:#A80036;stroke-width:1.0;stroke-dasharray:5.0,5.0;" x1="299" x2="299" y1="143.998" y2="2341.3594"/><line style="stroke:#A80036;stroke-width:1.0;stroke-dasharray:5.0,5.0;" x1="386" x2="386" y1="143.998" y2="2341.3594"/><line style="stroke:#A80036;stroke-width:1.0;stroke-dasharray:5.0,5.0;" x1="477" x2="477" y1="143.998" y2="2341.3594"/><line style="stroke:#A80036;stroke-width:1.0;stroke-dasharray:5.0,5.0;" x1="571.5" x2="571.5" y1="143.998" y2="2341.3594"/><line style="stroke:#A80036;stroke-width:1.0;stroke-dasharray:5.0,5.0;" x1="709" x2="709" y1="143.998" y2="2341.3594"/><line style="stroke:#A80036;stroke-width:1.0;stroke-dasharray:5.0,5.0;" x1="846" x2="846" y1="143.998" y2="2341.3594"/><line style="stroke:#A80036;stroke-width:1.0;stroke-dasharray:5.0,5.0;" x1="1136" x2="1136" y1="143.998" y2="2341.3594"/><line style="stroke:#A80036;stroke-width:1.0;stroke-dasharray:5.0,5.0;" x1="1267" x2="1267" y1="143.998" y2="2341.3594"/><line style="stroke:#A80036;stroke-width:1.0;stroke-dasharray:5.0,5.0;" x1="1406" x2="1406" y1="143.998" y2="2341.3594"/><text fill="#000000" font-family="sans-serif" font-size="14" lengthAdjust="spacing" textLength="33" x="27.5" y="141.0449">Alice</text><ellipse cx="47" cy="70.5098" fill="#FEFECE" filter="url(#f1d4shlhj7bai8)" rx="8" ry="8" style="stroke:#A80036;stroke-width:2.0;"/><path d="M47,78.5098 L47,105.5098 M34,86.5098 L60,86.5098 M47,105.5098 L34,120.5098 M47,105.5098 L60,120.5098 " fill="none" filter="url(#f1d4shlhj7bai8)" style="stroke:#A80036;stroke-width:2.0;"/><text fill="#000000" font-family="sans-serif" font-size="14" lengthAdjust="spacing" textLength="33" x="27.5" y="2353.8945">Alice</text><ellipse cx="47" cy="2366.8477" fill="#FEFECE" filter="url(#f1d4shlhj7bai8)" rx="8" ry="8" style="stroke:#A80036;stroke-width:2.0;"/><path d="M47,2374.8477 L47,2401.8477 M34,2382.8477 L60,2382.8477 M47,2401.8477 L34,2416.8477 M47,2401.8477 L60,2416.8477 " fill="none" filter="url(#f1d4shlhj7bai8)" style="stroke:#A80036;stroke-width:2.0;"/><text fill="#000000" font-family="sans-serif" font-size="14" lengthAdjust="spacing" textLength="45" x="274" y="141.0449">Forum</text><ellipse cx="299.5" cy="70.5098" fill="#FEFECE" filter="url(#f1d4shlhj7bai8)" rx="8" ry="8" style="stroke:#A80036;stroke-width:2.0;"/><path d="M299.5,78.5098 L299.5,105.5098 M286.5,86.5098 L312.5,86.5098 M299.5,105.5098 L286.5,120.5098 M299.5,105.5098 L312.5,120.5098 " fill="none" filter="url(#f1d4shlhj7bai8)" style="stroke:#A80036;stroke-width:2.0;"/><text fill="#000000" font-family="sans-serif" font-size="14" lengthAdjust="spacing" textLength="45" x="274" y="2353.8945">Forum</text><ellipse cx="299.5" cy="2366.8477" fill="#FEFECE" filter="url(#f1d4shlhj7bai8)" rx="8" ry="8" style="stroke:#A80036;stroke-width:2.0;"/><path d="M299.5,2374.8477 L299.5,2401.8477 M286.5,2382.8477 L312.5,2382.8477 M299.5,2401.8477 L286.5,2416.8477 M299.5,2401.8477 L312.5,2416.8477 " fill="none" filter="url(#f1d4shlhj7bai8)" style="stroke:#A80036;stroke-width:2.0;"/><text fill="#000000" font-family="sans-serif" font-size="14" lengthAdjust="spacing" textLength="79" x="344" y="141.0449">Community</text><ellipse cx="386.5" cy="70.5098" fill="#FEFECE" filter="url(#f1d4shlhj7bai8)" rx="8" ry="8" style="stroke:#A80036;stroke-width:2.0;"/><path d="M386.5,78.5098 L386.5,105.5098 M373.5,86.5098 L399.5,86.5098 M386.5,105.5098 L373.5,120.5098 M386.5,105.5098 L399.5,120.5098 " fill="none" filter="url(#f1d4shlhj7bai8)" style="stroke:#A80036;stroke-width:2.0;"/><text fill="#000000" font-family="sans-serif" font-size="14" lengthAdjust="spacing" textLength="79" x="344" y="2353.8945">Community</text><ellipse cx="386.5" cy="2366.8477" fill="#FEFECE" filter="url(#f1d4shlhj7bai8)" rx="8" ry="8" style="stroke:#A80036;stroke-width:2.0;"/><path d="M386.5,2374.8477 L386.5,2401.8477 M373.5,2382.8477 L399.5,2382.8477 M386.5,2401.8477 L373.5,2416.8477 M386.5,2401.8477 L399.5,2416.8477 " fill="none" filter="url(#f1d4shlhj7bai8)" style="stroke:#A80036;stroke-width:2.0;"/><text fill="#000000" font-family="sans-serif" font-size="14" lengthAdjust="spacing" textLength="70" x="439" y="141.0449">Guarantor</text><ellipse cx="477" cy="70.5098" fill="#FEFECE" filter="url(#f1d4shlhj7bai8)" rx="8" ry="8" style="stroke:#A80036;stroke-width:2.0;"/><path d="M477,78.5098 L477,105.5098 M464,86.5098 L490,86.5098 M477,105.5098 L464,120.5098 M477,105.5098 L490,120.5098 " fill="none" filter="url(#f1d4shlhj7bai8)" style="stroke:#A80036;stroke-width:2.0;"/><text fill="#000000" font-family="sans-serif" font-size="14" lengthAdjust="spacing" textLength="70" x="439" y="2353.8945">Guarantor</text><ellipse cx="477" cy="2366.8477" fill="#FEFECE" filter="url(#f1d4shlhj7bai8)" rx="8" ry="8" style="stroke:#A80036;stroke-width:2.0;"/><path d="M477,2374.8477 L477,2401.8477 M464,2382.8477 L490,2382.8477 M477,2401.8477 L464,2416.8477 M477,2401.8477 L490,2416.8477 " fill="none" filter="url(#f1d4shlhj7bai8)" style="stroke:#A80036;stroke-width:2.0;"/><text fill="#000000" font-family="sans-serif" font-size="14" lengthAdjust="spacing" textLength="64" x="536.5" y="141.0449">Snapshot</text><path d="M553.5,91.5098 C553.5,81.5098 571.5,81.5098 571.5,81.5098 C571.5,81.5098 589.5,81.5098 589.5,91.5098 L589.5,117.5098 C589.5,127.5098 571.5,127.5098 571.5,127.5098 C571.5,127.5098 553.5,127.5098 553.5,117.5098 L553.5,91.5098 " fill="#FEFECE" filter="url(#f1d4shlhj7bai8)" style="stroke:#000000;stroke-width:1.5;"/><path d="M553.5,91.5098 C553.5,101.5098 571.5,101.5098 571.5,101.5098 C571.5,101.5098 589.5,101.5098 589.5,91.5098 " fill="none" style="stroke:#000000;stroke-width:1.5;"/><text fill="#000000" font-family="sans-serif" font-size="14" lengthAdjust="spacing" textLength="64" x="536.5" y="2353.8945">Snapshot</text><path d="M553.5,2366.8477 C553.5,2356.8477 571.5,2356.8477 571.5,2356.8477 C571.5,2356.8477 589.5,2356.8477 589.5,2366.8477 L589.5,2392.8477 C589.5,2402.8477 571.5,2402.8477 571.5,2402.8477 C571.5,2402.8477 553.5,2402.8477 553.5,2392.8477 L553.5,2366.8477 " fill="#FEFECE" filter="url(#f1d4shlhj7bai8)" style="stroke:#000000;stroke-width:1.5;"/><path d="M553.5,2366.8477 C553.5,2376.8477 571.5,2376.8477 571.5,2376.8477 C571.5,2376.8477 589.5,2376.8477 589.5,2366.8477 " fill="none" style="stroke:#000000;stroke-width:1.5;"/><text fill="#000000" font-family="sans-serif" font-size="14" lengthAdjust="spacing" textLength="93" x="660" y="141.0449">BitDAOAdmin</text><ellipse cx="709.5" cy="70.5098" fill="#FEFECE" filter="url(#f1d4shlhj7bai8)" rx="8" ry="8" style="stroke:#A80036;stroke-width:2.0;"/><path d="M709.5,78.5098 L709.5,105.5098 M696.5,86.5098 L722.5,86.5098 M709.5,105.5098 L696.5,120.5098 M709.5,105.5098 L722.5,120.5098 " fill="none" filter="url(#f1d4shlhj7bai8)" style="stroke:#A80036;stroke-width:2.0;"/><text fill="#000000" font-family="sans-serif" font-size="14" lengthAdjust="spacing" textLength="93" x="660" y="2353.8945">BitDAOAdmin</text><ellipse cx="709.5" cy="2366.8477" fill="#FEFECE" filter="url(#f1d4shlhj7bai8)" rx="8" ry="8" style="stroke:#A80036;stroke-width:2.0;"/><path d="M709.5,2374.8477 L709.5,2401.8477 M696.5,2382.8477 L722.5,2382.8477 M709.5,2401.8477 L696.5,2416.8477 M709.5,2401.8477 L722.5,2416.8477 " fill="none" filter="url(#f1d4shlhj7bai8)" style="stroke:#A80036;stroke-width:2.0;"/><rect fill="#FEFECE" filter="url(#f1d4shlhj7bai8)" height="30.4883" style="stroke:#A80036;stroke-width:1.5;" width="49" x="822" y="104.5098"/><rect fill="#FEFECE" filter="url(#f1d4shlhj7bai8)" height="30.4883" style="stroke:#A80036;stroke-width:1.5;" width="49" x="818" y="108.5098"/><text fill="#000000" font-family="sans-serif" font-size="14" lengthAdjust="spacing" textLength="35" x="825" y="129.0449">Bond</text><rect fill="#FEFECE" filter="url(#f1d4shlhj7bai8)" height="30.4883" style="stroke:#A80036;stroke-width:1.5;" width="49" x="822" y="2340.3594"/><rect fill="#FEFECE" filter="url(#f1d4shlhj7bai8)" height="30.4883" style="stroke:#A80036;stroke-width:1.5;" width="49" x="818" y="2344.3594"/><text fill="#000000" font-family="sans-serif" font-size="14" lengthAdjust="spacing" textLength="35" x="825" y="2364.8945">Bond</text><rect fill="#FEFECE" filter="url(#f1d4shlhj7bai8)" height="30.4883" style="stroke:#A80036;stroke-width:1.5;" width="99" x="1087" y="104.5098"/><rect fill="#FEFECE" filter="url(#f1d4shlhj7bai8)" height="30.4883" style="stroke:#A80036;stroke-width:1.5;" width="99" x="1083" y="108.5098"/><text fill="#000000" font-family="sans-serif" font-size="14" lengthAdjust="spacing" textLength="85" x="1090" y="129.0449">BondFactory</text><rect fill="#FEFECE" filter="url(#f1d4shlhj7bai8)" height="30.4883" style="stroke:#A80036;stroke-width:1.5;" width="99" x="1087" y="2340.3594"/><rect fill="#FEFECE" filter="url(#f1d4shlhj7bai8)" height="30.4883" style="stroke:#A80036;stroke-width:1.5;" width="99" x="1083" y="2344.3594"/><text fill="#000000" font-family="sans-serif" font-size="14" lengthAdjust="spacing" textLength="85" x="1090" y="2364.8945">BondFactory</text><rect fill="#FEFECE" filter="url(#f1d4shlhj7bai8)" height="30.4883" style="stroke:#A80036;stroke-width:1.5;" width="119" x="1208" y="104.5098"/><rect fill="#FEFECE" filter="url(#f1d4shlhj7bai8)" height="30.4883" style="stroke:#A80036;stroke-width:1.5;" width="119" x="1204" y="108.5098"/><text fill="#000000" font-family="sans-serif" font-size="14" lengthAdjust="spacing" textLength="105" x="1211" y="129.0449">GrantsTreasury</text><rect fill="#FEFECE" filter="url(#f1d4shlhj7bai8)" height="30.4883" style="stroke:#A80036;stroke-width:1.5;" width="119" x="1208" y="2340.3594"/><rect fill="#FEFECE" filter="url(#f1d4shlhj7bai8)" height="30.4883" style="stroke:#A80036;stroke-width:1.5;" width="119" x="1204" y="2344.3594"/><text fill="#000000" font-family="sans-serif" font-size="14" lengthAdjust="spacing" textLength="105" x="1211" y="2364.8945">GrantsTreasury</text><rect fill="#FEFECE" filter="url(#f1d4shlhj7bai8)" height="30.4883" style="stroke:#A80036;stroke-width:1.5;" width="122" x="1345" y="104.5098"/><rect fill="#FEFECE" filter="url(#f1d4shlhj7bai8)" height="30.4883" style="stroke:#A80036;stroke-width:1.5;" width="122" x="1341" y="108.5098"/><text fill="#000000" font-family="sans-serif" font-size="14" lengthAdjust="spacing" textLength="108" x="1348" y="129.0449">BitDAOTreasury</text><rect fill="#FEFECE" filter="url(#f1d4shlhj7bai8)" height="30.4883" style="stroke:#A80036;stroke-width:1.5;" width="122" x="1345" y="2340.3594"/><rect fill="#FEFECE" filter="url(#f1d4shlhj7bai8)" height="30.4883" style="stroke:#A80036;stroke-width:1.5;" width="122" x="1341" y="2344.3594"/><text fill="#000000" font-family="sans-serif" font-size="14" lengthAdjust="spacing" textLength="108" x="1348" y="2364.8945">BitDAOTreasury</text><rect fill="#EEEEEE" filter="url(#f1d4shlhj7bai8)" height="3" style="stroke:#EEEEEE;stroke-width:1.0;" width="1491" x="0" y="174.6533"/><line style="stroke:#000000;stroke-width:1.0;" x1="0" x2="1491" y1="174.6533" y2="174.6533"/><line style="stroke:#000000;stroke-width:1.0;" x1="0" x2="1491" y1="177.6533" y2="177.6533"/><rect fill="#EEEEEE" filter="url(#f1d4shlhj7bai8)" height="23.3105" style="stroke:#000000;stroke-width:2.0;" width="272" x="609.5" y="163.998"/><text fill="#000000" font-family="sans-serif" font-size="13" font-weight="bold" lengthAdjust="spacing" textLength="254" x="615.5" y="180.5664">Deciding funds, bond and guarantors</text><polygon fill="#A80036" points="287.5,227.2744,297.5,231.2744,287.5,235.2744,291.5,231.2744" style="stroke:#A80036;stroke-width:1.0;"/><line style="stroke:#A80036;stroke-width:1.0;" x1="47" x2="293.5" y1="231.2744" y2="231.2744"/><text fill="#000000" font-family="sans-serif" font-size="13" lengthAdjust="spacing" textLength="120" x="54" y="226.5322">post outlining plan</text><path d="M304,202.3086 L304,242.3086 L431,242.3086 L431,212.3086 L421,202.3086 L304,202.3086 " fill="#FBFB77" filter="url(#f1d4shlhj7bai8)" style="stroke:#A80036;stroke-width:1.0;"/><path d="M421,202.3086 L421,212.3086 L431,212.3086 L421,202.3086 " fill="#FBFB77" style="stroke:#A80036;stroke-width:1.0;"/><text fill="#000000" font-family="sans-serif" font-size="13" lengthAdjust="spacing" textLength="106" x="310" y="219.877">100 ETH wanted,</text><text fill="#000000" font-family="sans-serif" font-size="13" lengthAdjust="spacing" textLength="91" x="310" y="235.1875">150K BIT bond</text><polygon fill="#A80036" points="310.5,269.2402,300.5,273.2402,310.5,277.2402,306.5,273.2402" style="stroke:#A80036;stroke-width:1.0;"/><line style="stroke:#A80036;stroke-width:1.0;" x1="304.5" x2="385.5" y1="273.2402" y2="273.2402"/><text fill="#000000" font-family="sans-serif" font-size="13" lengthAdjust="spacing" textLength="57" x="316.5" y="268.498">feedback</text><polygon fill="#A80036" points="310.5,303.5508,300.5,307.5508,310.5,311.5508,306.5,307.5508" style="stroke:#A80036;stroke-width:1.0;"/><line style="stroke:#A80036;stroke-width:1.0;" x1="304.5" x2="476" y1="307.5508" y2="307.5508"/><text fill="#000000" font-family="sans-serif" font-size="13" lengthAdjust="spacing" textLength="116" x="316.5" y="302.8086">agree to guarantor</text><path d="M482,286.2402 L482,311.2402 L689,311.2402 L689,296.2402 L679,286.2402 L482,286.2402 " fill="#FBFB77" filter="url(#f1d4shlhj7bai8)" style="stroke:#A80036;stroke-width:1.0;"/><path d="M679,286.2402 L679,296.2402 L689,296.2402 L679,286.2402 " fill="#FBFB77" style="stroke:#A80036;stroke-width:1.0;"/><text fill="#000000" font-family="sans-serif" font-size="13" lengthAdjust="spacing" textLength="186" x="488" y="303.8086">May have multiple guarantors</text><polygon fill="#A80036" points="58,337.8613,48,341.8613,58,345.8613,54,341.8613" style="stroke:#A80036;stroke-width:1.0;"/><line style="stroke:#A80036;stroke-width:1.0;stroke-dasharray:2.0,2.0;" x1="52" x2="298.5" y1="341.8613" y2="341.8613"/><text fill="#000000" font-family="sans-serif" font-size="13" lengthAdjust="spacing" textLength="138" x="64" y="337.1191">quorum of guarantors</text><rect fill="#EEEEEE" filter="url(#f1d4shlhj7bai8)" height="3" style="stroke:#EEEEEE;stroke-width:1.0;" width="1491" x="0" y="370.5166"/><line style="stroke:#000000;stroke-width:1.0;" x1="0" x2="1491" y1="370.5166" y2="370.5166"/><line style="stroke:#000000;stroke-width:1.0;" x1="0" x2="1491" y1="373.5166" y2="373.5166"/><rect fill="#EEEEEE" filter="url(#f1d4shlhj7bai8)" height="23.3105" style="stroke:#000000;stroke-width:2.0;" width="112" x="689.5" y="359.8613"/><text fill="#000000" font-family="sans-serif" font-size="13" font-weight="bold" lengthAdjust="spacing" textLength="94" x="695.5" y="376.4297">Bond Funding</text><polygon fill="#A80036" points="1124.5,410.4824,1134.5,414.4824,1124.5,418.4824,1128.5,414.4824" style="stroke:#A80036;stroke-width:1.0;"/><line style="stroke:#A80036;stroke-width:1.0;" x1="47" x2="1130.5" y1="414.4824" y2="414.4824"/><text fill="#000000" font-family="sans-serif" font-size="13" lengthAdjust="spacing" textLength="138" x="54" y="409.7402">request bond creation</text><polygon fill="#A80036" points="857.5,439.793,847.5,443.793,857.5,447.793,853.5,443.793" style="stroke:#A80036;stroke-width:1.0;"/><line style="stroke:#A80036;stroke-width:1.0;" x1="851.5" x2="1135.5" y1="443.793" y2="443.793"/><text fill="#000000" font-family="sans-serif" font-size="13" lengthAdjust="spacing" textLength="38" x="863.5" y="439.0508">create</text><line style="stroke:#A80036;stroke-width:1.0;" x1="1136.5" x2="1178.5" y1="473.1035" y2="473.1035"/><line style="stroke:#A80036;stroke-width:1.0;" x1="1178.5" x2="1178.5" y1="473.1035" y2="486.1035"/><line style="stroke:#A80036;stroke-width:1.0;" x1="1137.5" x2="1178.5" y1="486.1035" y2="486.1035"/><polygon fill="#A80036" points="1147.5,482.1035,1137.5,486.1035,1147.5,490.1035,1143.5,486.1035" style="stroke:#A80036;stroke-width:1.0;"/><text fill="#000000" font-family="sans-serif" font-size="13" lengthAdjust="spacing" textLength="117" x="1143.5" y="468.3613">emit bond address</text><polygon fill="#A80036" points="58,511.4141,48,515.4141,58,519.4141,54,515.4141" style="stroke:#A80036;stroke-width:1.0;"/><line style="stroke:#A80036;stroke-width:1.0;stroke-dasharray:2.0,2.0;" x1="52" x2="1135.5" y1="515.4141" y2="515.4141"/><text fill="#000000" font-family="sans-serif" font-size="13" lengthAdjust="spacing" textLength="85" x="64" y="510.6719">bond address</text><polygon fill="#A80036" points="287.5,540.7246,297.5,544.7246,287.5,548.7246,291.5,544.7246" style="stroke:#A80036;stroke-width:1.0;"/><line style="stroke:#A80036;stroke-width:1.0;" x1="47" x2="293.5" y1="544.7246" y2="544.7246"/><text fill="#000000" font-family="sans-serif" font-size="13" lengthAdjust="spacing" textLength="78" x="54" y="539.9824">bond details</text><polygon fill="#A80036" points="465,570.0352,475,574.0352,465,578.0352,469,574.0352" style="stroke:#A80036;stroke-width:1.0;"/><line style="stroke:#A80036;stroke-width:1.0;" x1="299.5" x2="471" y1="574.0352" y2="574.0352"/><text fill="#000000" font-family="sans-serif" font-size="13" lengthAdjust="spacing" textLength="85" x="306.5" y="569.293">bond address</text><path d="M698,587.0352 L698,612.0352 L837,612.0352 L837,597.0352 L827,587.0352 L698,587.0352 " fill="#FBFB77" filter="url(#f1d4shlhj7bai8)" style="stroke:#A80036;stroke-width:1.0;"/><path d="M827,587.0352 L827,597.0352 L837,597.0352 L827,587.0352 " fill="#FBFB77" style="stroke:#A80036;stroke-width:1.0;"/><text fill="#000000" font-family="sans-serif" font-size="13" lengthAdjust="spacing" textLength="118" x="704" y="604.6035">Bond balance 0 BIT</text><path d="M429,628.3457 L708,628.3457 L708,635.3457 L698,645.3457 L429,645.3457 L429,628.3457 " fill="#D3D3D3" style="stroke:#000000;stroke-width:1.0;"/><rect fill="none" height="75.9316" style="stroke:#000000;stroke-width:2.0;" width="456" x="429" y="628.3457"/><text fill="#000000" font-family="sans-serif" font-size="13" font-weight="bold" lengthAdjust="spacing" textLength="234" x="444" y="641.9141">Repeats until bond target satisfied</text><polygon fill="#A80036" points="834.5,662.9668,844.5,666.9668,834.5,670.9668,838.5,666.9668" style="stroke:#A80036;stroke-width:1.0;"/><line style="stroke:#A80036;stroke-width:1.0;" x1="477" x2="840.5" y1="666.9668" y2="666.9668"/><text fill="#000000" font-family="sans-serif" font-size="13" lengthAdjust="spacing" textLength="83" x="484" y="662.2246">deposit bond</text><polygon fill="#A80036" points="488,692.2773,478,696.2773,488,700.2773,484,696.2773" style="stroke:#A80036;stroke-width:1.0;"/><line style="stroke:#A80036;stroke-width:1.0;stroke-dasharray:2.0,2.0;" x1="482" x2="845.5" y1="696.2773" y2="696.2773"/><text fill="#000000" font-family="sans-serif" font-size="13" lengthAdjust="spacing" textLength="209" x="494" y="691.5352">receive bond certificates (tokens)</text><path d="M674,716.2773 L674,741.2773 L837,741.2773 L837,726.2773 L827,716.2773 L674,716.2773 " fill="#FBFB77" filter="url(#f1d4shlhj7bai8)" style="stroke:#A80036;stroke-width:1.0;"/><path d="M827,716.2773 L827,726.2773 L837,726.2773 L827,716.2773 " fill="#FBFB77" style="stroke:#A80036;stroke-width:1.0;"/><text fill="#000000" font-family="sans-serif" font-size="13" lengthAdjust="spacing" textLength="142" x="680" y="733.8457">Bond balance 150K BIT</text><path d="M204,755.5879 L204,780.5879 L468,780.5879 L468,765.5879 L458,755.5879 L204,755.5879 " fill="#FBFB77" filter="url(#f1d4shlhj7bai8)" style="stroke:#A80036;stroke-width:1.0;"/><path d="M458,755.5879 L458,765.5879 L468,765.5879 L458,755.5879 " fill="#FBFB77" style="stroke:#A80036;stroke-width:1.0;"/><text fill="#000000" font-family="sans-serif" font-size="13" lengthAdjust="spacing" textLength="243" x="210" y="773.1563">Guarantors hold 150K debt certificates</text><polygon fill="#A80036" points="58,807.209,48,811.209,58,815.209,54,811.209" style="stroke:#A80036;stroke-width:1.0;"/><line style="stroke:#A80036;stroke-width:1.0;stroke-dasharray:2.0,2.0;" x1="52" x2="845.5" y1="811.209" y2="811.209"/><text fill="#000000" font-family="sans-serif" font-size="13" lengthAdjust="spacing" textLength="121" x="64" y="806.4668">Bond collateral met</text><rect fill="#EEEEEE" filter="url(#f1d4shlhj7bai8)" height="3" style="stroke:#EEEEEE;stroke-width:1.0;" width="1491" x="0" y="839.8643"/><line style="stroke:#000000;stroke-width:1.0;" x1="0" x2="1491" y1="839.8643" y2="839.8643"/><line style="stroke:#000000;stroke-width:1.0;" x1="0" x2="1491" y1="842.8643" y2="842.8643"/><rect fill="#EEEEEE" filter="url(#f1d4shlhj7bai8)" height="23.3105" style="stroke:#000000;stroke-width:2.0;" width="188" x="651.5" y="829.209"/><text fill="#000000" font-family="sans-serif" font-size="13" font-weight="bold" lengthAdjust="spacing" textLength="170" x="657.5" y="845.7773">Grants Treasury Funding</text><polygon fill="#A80036" points="559.5,879.8301,569.5,883.8301,559.5,887.8301,563.5,883.8301" style="stroke:#A80036;stroke-width:1.0;"/><line style="stroke:#A80036;stroke-width:1.0;" x1="47" x2="565.5" y1="883.8301" y2="883.8301"/><text fill="#000000" font-family="sans-serif" font-size="13" lengthAdjust="spacing" textLength="103" x="54" y="879.0879">submit proposal</text><polygon fill="#A80036" points="397.5,909.1406,387.5,913.1406,397.5,917.1406,393.5,913.1406" style="stroke:#A80036;stroke-width:1.0;"/><line style="stroke:#A80036;stroke-width:1.0;stroke-dasharray:2.0,2.0;" x1="391.5" x2="570.5" y1="913.1406" y2="913.1406"/><text fill="#000000" font-family="sans-serif" font-size="13" lengthAdjust="spacing" textLength="161" x="403.5" y="908.3984">new proposal notification</text><polygon fill="#A80036" points="559.5,938.4512,569.5,942.4512,559.5,946.4512,563.5,942.4512" style="stroke:#A80036;stroke-width:1.0;"/><line style="stroke:#A80036;stroke-width:1.0;" x1="386.5" x2="565.5" y1="942.4512" y2="942.4512"/><text fill="#000000" font-family="sans-serif" font-size="13" lengthAdjust="spacing" textLength="106" x="393.5" y="937.709">vote on proposal</text><path d="M419,957.4512 L578,957.4512 L578,964.4512 L568,974.4512 L419,974.4512 L419,957.4512 " fill="#FFFFFF" style="stroke:#000000;stroke-width:1.0;"/><rect fill="none" height="468.3027" style="stroke:#000000;stroke-width:2.0;" width="1062" x="419" y="957.4512"/><text fill="#000000" font-family="sans-serif" font-size="13" font-weight="bold" lengthAdjust="spacing" textLength="114" x="434" y="971.0195">Proposal success</text><path d="M1272,979.7617 L1272,1004.7617 L1427,1004.7617 L1427,989.7617 L1417,979.7617 L1272,979.7617 " fill="#FBFB77" filter="url(#f1d4shlhj7bai8)" style="stroke:#A80036;stroke-width:1.0;"/><path d="M1417,979.7617 L1417,989.7617 L1427,989.7617 L1417,979.7617 " fill="#FBFB77" style="stroke:#A80036;stroke-width:1.0;"/><text fill="#000000" font-family="sans-serif" font-size="13" lengthAdjust="spacing" textLength="134" x="1278" y="997.3301">Grants balance 0 ETH</text><polygon fill="#A80036" points="697.5,1031.3828,707.5,1035.3828,697.5,1039.3828,701.5,1035.3828" style="stroke:#A80036;stroke-width:1.0;"/><line style="stroke:#A80036;stroke-width:1.0;" x1="571.5" x2="703.5" y1="1035.3828" y2="1035.3828"/><text fill="#000000" font-family="sans-serif" font-size="13" lengthAdjust="spacing" textLength="109" x="578.5" y="1030.6406">proposal success</text><polygon fill="#A80036" points="1394,1060.6934,1404,1064.6934,1394,1068.6934,1398,1064.6934" style="stroke:#A80036;stroke-width:1.0;"/><line style="stroke:#A80036;stroke-width:1.0;" x1="709.5" x2="1400" y1="1064.6934" y2="1064.6934"/><text fill="#000000" font-family="sans-serif" font-size="13" lengthAdjust="spacing" textLength="293" x="716.5" y="1059.9512">perform transfer of 100 ETH to GrantsTreasury</text><polygon fill="#A80036" points="1278.5,1090.0039,1268.5,1094.0039,1278.5,1098.0039,1274.5,1094.0039" style="stroke:#A80036;stroke-width:1.0;"/><line style="stroke:#A80036;stroke-width:1.0;" x1="1272.5" x2="1405" y1="1094.0039" y2="1094.0039"/><text fill="#000000" font-family="sans-serif" font-size="13" lengthAdjust="spacing" textLength="89" x="1284.5" y="1089.2617">transfer funds</text><path d="M1272,1107.0039 L1272,1132.0039 L1443,1132.0039 L1443,1117.0039 L1433,1107.0039 L1272,1107.0039 " fill="#FBFB77" filter="url(#f1d4shlhj7bai8)" style="stroke:#A80036;stroke-width:1.0;"/><path d="M1433,1107.0039 L1433,1117.0039 L1443,1117.0039 L1433,1107.0039 " fill="#FBFB77" style="stroke:#A80036;stroke-width:1.0;"/><text fill="#000000" font-family="sans-serif" font-size="13" lengthAdjust="spacing" textLength="150" x="1278" y="1124.5723">Grants balance 100 ETH</text><line style="stroke:#000000;stroke-width:1.0;stroke-dasharray:2.0,2.0;" x1="419" x2="1481" y1="1142.3145" y2="1142.3145"/><text fill="#000000" font-family="sans-serif" font-size="11" font-weight="bold" lengthAdjust="spacing" textLength="105" x="424" y="1152.9492">[Proposal rejected]</text><path d="M674,1161.2695 L674,1186.2695 L837,1186.2695 L837,1171.2695 L827,1161.2695 L674,1161.2695 " fill="#FBFB77" filter="url(#f1d4shlhj7bai8)" style="stroke:#A80036;stroke-width:1.0;"/><path d="M827,1161.2695 L827,1171.2695 L837,1171.2695 L827,1161.2695 " fill="#FBFB77" style="stroke:#A80036;stroke-width:1.0;"/><text fill="#000000" font-family="sans-serif" font-size="13" lengthAdjust="spacing" textLength="142" x="680" y="1178.8379">Bond balance 150K BIT</text><polygon fill="#A80036" points="697.5,1212.8906,707.5,1216.8906,697.5,1220.8906,701.5,1216.8906" style="stroke:#A80036;stroke-width:1.0;"/><line style="stroke:#A80036;stroke-width:1.0;" x1="571.5" x2="703.5" y1="1216.8906" y2="1216.8906"/><text fill="#000000" font-family="sans-serif" font-size="13" lengthAdjust="spacing" textLength="94" x="578.5" y="1212.1484">proposal failed</text><polygon fill="#A80036" points="834.5,1242.2012,844.5,1246.2012,834.5,1250.2012,838.5,1246.2012" style="stroke:#A80036;stroke-width:1.0;"/><line style="stroke:#A80036;stroke-width:1.0;" x1="709.5" x2="840.5" y1="1246.2012" y2="1246.2012"/><text fill="#000000" font-family="sans-serif" font-size="13" lengthAdjust="spacing" textLength="80" x="716.5" y="1241.459">release bond</text><line style="stroke:#A80036;stroke-width:1.0;" x1="846.5" x2="888.5" y1="1275.5117" y2="1275.5117"/><line style="stroke:#A80036;stroke-width:1.0;" x1="888.5" x2="888.5" y1="1275.5117" y2="1288.5117"/><line style="stroke:#A80036;stroke-width:1.0;" x1="847.5" x2="888.5" y1="1288.5117" y2="1288.5117"/><polygon fill="#A80036" points="857.5,1284.5117,847.5,1288.5117,857.5,1292.5117,853.5,1288.5117" style="stroke:#A80036;stroke-width:1.0;"/><text fill="#000000" font-family="sans-serif" font-size="13" lengthAdjust="spacing" textLength="276" x="853.5" y="1270.7695">unlock BIT tokens for guarantor redemption</text><path d="M429,1303.5117 L665,1303.5117 L665,1310.5117 L655,1320.5117 L429,1320.5117 L429,1303.5117 " fill="#D3D3D3" style="stroke:#000000;stroke-width:1.0;"/><rect fill="none" height="75.9316" style="stroke:#000000;stroke-width:2.0;" width="456" x="429" y="1303.5117"/><text fill="#000000" font-family="sans-serif" font-size="13" font-weight="bold" lengthAdjust="spacing" textLength="191" x="444" y="1317.0801">Repeat until full redemption</text><polygon fill="#A80036" points="834.5,1338.1328,844.5,1342.1328,834.5,1346.1328,838.5,1342.1328" style="stroke:#A80036;stroke-width:1.0;"/><line style="stroke:#A80036;stroke-width:1.0;" x1="477" x2="840.5" y1="1342.1328" y2="1342.1328"/><text fill="#000000" font-family="sans-serif" font-size="13" lengthAdjust="spacing" textLength="163" x="484" y="1337.3906">exchange bond certificate</text><polygon fill="#A80036" points="488,1367.4434,478,1371.4434,488,1375.4434,484,1371.4434" style="stroke:#A80036;stroke-width:1.0;"/><line style="stroke:#A80036;stroke-width:1.0;stroke-dasharray:2.0,2.0;" x1="482" x2="845.5" y1="1371.4434" y2="1371.4434"/><text fill="#000000" font-family="sans-serif" font-size="13" lengthAdjust="spacing" textLength="165" x="494" y="1366.7012">receive bonded BIT tokens</text><path d="M698,1391.4434 L698,1416.4434 L837,1416.4434 L837,1401.4434 L827,1391.4434 L698,1391.4434 " fill="#FBFB77" filter="url(#f1d4shlhj7bai8)" style="stroke:#A80036;stroke-width:1.0;"/><path d="M827,1391.4434 L827,1401.4434 L837,1401.4434 L827,1391.4434 " fill="#FBFB77" style="stroke:#A80036;stroke-width:1.0;"/><text fill="#000000" font-family="sans-serif" font-size="13" lengthAdjust="spacing" textLength="118" x="704" y="1409.0117">Bond balance 0 BIT</text><rect fill="#EEEEEE" filter="url(#f1d4shlhj7bai8)" height="3" style="stroke:#EEEEEE;stroke-width:1.0;" width="1491" x="0" y="1453.4092"/><line style="stroke:#000000;stroke-width:1.0;" x1="0" x2="1491" y1="1453.4092" y2="1453.4092"/><line style="stroke:#000000;stroke-width:1.0;" x1="0" x2="1491" y1="1456.4092" y2="1456.4092"/><rect fill="#EEEEEE" filter="url(#f1d4shlhj7bai8)" height="23.3105" style="stroke:#000000;stroke-width:2.0;" width="224" x="633.5" y="1442.7539"/><text fill="#000000" font-family="sans-serif" font-size="13" font-weight="bold" lengthAdjust="spacing" textLength="206" x="639.5" y="1459.3223">Bond Certification Redemption</text><line style="stroke:#A80036;stroke-width:1.0;" x1="47" x2="89" y1="1512.6855" y2="1512.6855"/><line style="stroke:#A80036;stroke-width:1.0;" x1="89" x2="89" y1="1512.6855" y2="1525.6855"/><line style="stroke:#A80036;stroke-width:1.0;" x1="48" x2="89" y1="1525.6855" y2="1525.6855"/><polygon fill="#A80036" points="58,1521.6855,48,1525.6855,58,1529.6855,54,1525.6855" style="stroke:#A80036;stroke-width:1.0;"/><text fill="#000000" font-family="sans-serif" font-size="13" lengthAdjust="spacing" textLength="44" x="54" y="1492.6328">project</text><text fill="#000000" font-family="sans-serif" font-size="13" lengthAdjust="spacing" textLength="49" x="54" y="1507.9434">delivery</text><polygon fill="#A80036" points="287.5,1566.3066,297.5,1570.3066,287.5,1574.3066,291.5,1570.3066" style="stroke:#A80036;stroke-width:1.0;"/><line style="stroke:#A80036;stroke-width:1.0;" x1="47" x2="293.5" y1="1570.3066" y2="1570.3066"/><text fill="#000000" font-family="sans-serif" font-size="13" lengthAdjust="spacing" textLength="118" x="54" y="1550.2539">temperature gauge</text><text fill="#000000" font-family="sans-serif" font-size="13" lengthAdjust="spacing" textLength="120" x="54" y="1565.5645">for project success</text><polygon fill="#A80036" points="58,1626.2383,48,1630.2383,58,1634.2383,54,1630.2383" style="stroke:#A80036;stroke-width:1.0;"/><line style="stroke:#A80036;stroke-width:1.0;stroke-dasharray:2.0,2.0;" x1="52" x2="298.5" y1="1630.2383" y2="1630.2383"/><text fill="#000000" font-family="sans-serif" font-size="13" lengthAdjust="spacing" textLength="200" x="64" y="1594.875">vote must include full payment,</text><text fill="#000000" font-family="sans-serif" font-size="13" lengthAdjust="spacing" textLength="142" x="64" y="1610.1855">partial slashing option</text><text fill="#000000" font-family="sans-serif" font-size="13" lengthAdjust="spacing" textLength="150" x="64" y="1625.4961">and full slashing option</text><polygon fill="#A80036" points="559.5,1655.5488,569.5,1659.5488,559.5,1663.5488,563.5,1659.5488" style="stroke:#A80036;stroke-width:1.0;"/><line style="stroke:#A80036;stroke-width:1.0;" x1="47" x2="565.5" y1="1659.5488" y2="1659.5488"/><text fill="#000000" font-family="sans-serif" font-size="13" lengthAdjust="spacing" textLength="254" x="54" y="1654.8066">proposal on bond certificate redemption</text><polygon fill="#A80036" points="397.5,1684.8594,387.5,1688.8594,397.5,1692.8594,393.5,1688.8594" style="stroke:#A80036;stroke-width:1.0;"/><line style="stroke:#A80036;stroke-width:1.0;stroke-dasharray:2.0,2.0;" x1="391.5" x2="570.5" y1="1688.8594" y2="1688.8594"/><text fill="#000000" font-family="sans-serif" font-size="13" lengthAdjust="spacing" textLength="161" x="403.5" y="1684.1172">new proposal notification</text><polygon fill="#A80036" points="559.5,1714.1699,569.5,1718.1699,559.5,1722.1699,563.5,1718.1699" style="stroke:#A80036;stroke-width:1.0;"/><line style="stroke:#A80036;stroke-width:1.0;" x1="386.5" x2="565.5" y1="1718.1699" y2="1718.1699"/><text fill="#000000" font-family="sans-serif" font-size="13" lengthAdjust="spacing" textLength="106" x="393.5" y="1713.4277">vote on proposal</text><polygon fill="#A80036" points="697.5,1743.4805,707.5,1747.4805,697.5,1751.4805,701.5,1747.4805" style="stroke:#A80036;stroke-width:1.0;"/><line style="stroke:#A80036;stroke-width:1.0;" x1="571.5" x2="703.5" y1="1747.4805" y2="1747.4805"/><text fill="#000000" font-family="sans-serif" font-size="13" lengthAdjust="spacing" textLength="114" x="578.5" y="1742.7383">proposal outcome</text><path d="M851,1760.4805 L851,1785.4805 L1068,1785.4805 L1068,1770.4805 L1058,1760.4805 L851,1760.4805 " fill="#FBFB77" filter="url(#f1d4shlhj7bai8)" style="stroke:#A80036;stroke-width:1.0;"/><path d="M1058,1760.4805 L1058,1770.4805 L1068,1770.4805 L1058,1760.4805 " fill="#FBFB77" style="stroke:#A80036;stroke-width:1.0;"/><text fill="#000000" font-family="sans-serif" font-size="13" lengthAdjust="spacing" textLength="196" x="857" y="1778.0488">Bond balance 150K BIT (locked)</text><path d="M419,1801.791 L610,1801.791 L610,1808.791 L600,1818.791 L419,1818.791 L419,1801.791 " fill="#FFFFFF" style="stroke:#000000;stroke-width:1.0;"/><rect fill="none" height="483.2578" style="stroke:#000000;stroke-width:2.0;" width="1062" x="419" y="1801.791"/><text fill="#000000" font-family="sans-serif" font-size="13" font-weight="bold" lengthAdjust="spacing" textLength="146" x="434" y="1815.3594">Full bond redemption</text><polygon fill="#A80036" points="834.5,1836.4121,844.5,1840.4121,834.5,1844.4121,838.5,1840.4121" style="stroke:#A80036;stroke-width:1.0;"/><line style="stroke:#A80036;stroke-width:1.0;" x1="709.5" x2="840.5" y1="1840.4121" y2="1840.4121"/><text fill="#000000" font-family="sans-serif" font-size="13" lengthAdjust="spacing" textLength="44" x="716.5" y="1835.6699">release</text><line style="stroke:#A80036;stroke-width:1.0;" x1="846.5" x2="888.5" y1="1869.7227" y2="1869.7227"/><line style="stroke:#A80036;stroke-width:1.0;" x1="888.5" x2="888.5" y1="1869.7227" y2="1882.7227"/><line style="stroke:#A80036;stroke-width:1.0;" x1="847.5" x2="888.5" y1="1882.7227" y2="1882.7227"/><polygon fill="#A80036" points="857.5,1878.7227,847.5,1882.7227,857.5,1886.7227,853.5,1882.7227" style="stroke:#A80036;stroke-width:1.0;"/><text fill="#000000" font-family="sans-serif" font-size="13" lengthAdjust="spacing" textLength="113" x="853.5" y="1864.9805">unlock BIT tokens</text><path d="M429,1897.7227 L665,1897.7227 L665,1904.7227 L655,1914.7227 L429,1914.7227 L429,1897.7227 " fill="#D3D3D3" style="stroke:#000000;stroke-width:1.0;"/><rect fill="none" height="75.9316" style="stroke:#000000;stroke-width:2.0;" width="456" x="429" y="1897.7227"/><text fill="#000000" font-family="sans-serif" font-size="13" font-weight="bold" lengthAdjust="spacing" textLength="191" x="444" y="1911.291">Repeat until full redemption</text><polygon fill="#A80036" points="834.5,1932.3438,844.5,1936.3438,834.5,1940.3438,838.5,1936.3438" style="stroke:#A80036;stroke-width:1.0;"/><line style="stroke:#A80036;stroke-width:1.0;" x1="477" x2="840.5" y1="1936.3438" y2="1936.3438"/><text fill="#000000" font-family="sans-serif" font-size="13" lengthAdjust="spacing" textLength="163" x="484" y="1931.6016">exchange bond certificate</text><polygon fill="#A80036" points="488,1961.6543,478,1965.6543,488,1969.6543,484,1965.6543" style="stroke:#A80036;stroke-width:1.0;"/><line style="stroke:#A80036;stroke-width:1.0;stroke-dasharray:2.0,2.0;" x1="482" x2="845.5" y1="1965.6543" y2="1965.6543"/><text fill="#000000" font-family="sans-serif" font-size="13" lengthAdjust="spacing" textLength="165" x="494" y="1960.9121">receive bonded BIT tokens</text><line style="stroke:#000000;stroke-width:1.0;stroke-dasharray:2.0,2.0;" x1="419" x2="1481" y1="1981.6543" y2="1981.6543"/><text fill="#000000" font-family="sans-serif" font-size="11" font-weight="bold" lengthAdjust="spacing" textLength="94" x="424" y="1992.2891">[Full bond slash]</text><polygon fill="#A80036" points="834.5,2012.9199,844.5,2016.9199,834.5,2020.9199,838.5,2016.9199" style="stroke:#A80036;stroke-width:1.0;"/><line style="stroke:#A80036;stroke-width:1.0;" x1="709.5" x2="840.5" y1="2016.9199" y2="2016.9199"/><text fill="#000000" font-family="sans-serif" font-size="13" lengthAdjust="spacing" textLength="94" x="716.5" y="2012.1777">slash full bond</text><polygon fill="#A80036" points="1394,2042.2305,1404,2046.2305,1394,2050.2305,1398,2046.2305" style="stroke:#A80036;stroke-width:1.0;"/><line style="stroke:#A80036;stroke-width:1.0;" x1="846.5" x2="1400" y1="2046.2305" y2="2046.2305"/><text fill="#000000" font-family="sans-serif" font-size="13" lengthAdjust="spacing" textLength="115" x="853.5" y="2041.4883">transfer all tokens</text><polygon fill="#A80036" points="857.5,2056.2305,847.5,2060.2305,857.5,2064.2305,853.5,2060.2305" style="stroke:#A80036;stroke-width:1.0;"/><line style="stroke:#A80036;stroke-width:1.0;stroke-dasharray:2.0,2.0;" x1="851.5" x2="1405" y1="2060.2305" y2="2060.2305"/><path d="M1259,2073.2305 L1259,2098.2305 L1397,2098.2305 L1397,2083.2305 L1387,2073.2305 L1259,2073.2305 " fill="#FBFB77" filter="url(#f1d4shlhj7bai8)" style="stroke:#A80036;stroke-width:1.0;"/><path d="M1387,2073.2305 L1387,2083.2305 L1397,2083.2305 L1387,2073.2305 " fill="#FBFB77" style="stroke:#A80036;stroke-width:1.0;"/><text fill="#000000" font-family="sans-serif" font-size="13" lengthAdjust="spacing" textLength="117" x="1265" y="2090.7988">balance +150K BIT</text><line style="stroke:#000000;stroke-width:1.0;stroke-dasharray:2.0,2.0;" x1="419" x2="1481" y1="2108.541" y2="2108.541"/><text fill="#000000" font-family="sans-serif" font-size="11" font-weight="bold" lengthAdjust="spacing" textLength="254" x="424" y="2119.1758">[Partial bond slashed, remaining redeemable]</text><polygon fill="#A80036" points="834.5,2139.8066,844.5,2143.8066,834.5,2147.8066,838.5,2143.8066" style="stroke:#A80036;stroke-width:1.0;"/><line style="stroke:#A80036;stroke-width:1.0;" x1="709.5" x2="840.5" y1="2143.8066" y2="2143.8066"/><text fill="#000000" font-family="sans-serif" font-size="13" lengthAdjust="spacing" textLength="113" x="716.5" y="2139.0645">slash partial bond</text><polygon fill="#A80036" points="1394,2169.1172,1404,2173.1172,1394,2177.1172,1398,2173.1172" style="stroke:#A80036;stroke-width:1.0;"/><line style="stroke:#A80036;stroke-width:1.0;" x1="846.5" x2="1400" y1="2173.1172" y2="2173.1172"/><text fill="#000000" font-family="sans-serif" font-size="13" lengthAdjust="spacing" textLength="96" x="853.5" y="2168.375">transfer tokens</text><polygon fill="#A80036" points="857.5,2183.1172,847.5,2187.1172,857.5,2191.1172,853.5,2187.1172" style="stroke:#A80036;stroke-width:1.0;"/><line style="stroke:#A80036;stroke-width:1.0;stroke-dasharray:2.0,2.0;" x1="851.5" x2="1405" y1="2187.1172" y2="2187.1172"/><path d="M429,2202.1172 L665,2202.1172 L665,2209.1172 L655,2219.1172 L429,2219.1172 L429,2202.1172 " fill="#D3D3D3" style="stroke:#000000;stroke-width:1.0;"/><rect fill="none" height="75.9316" style="stroke:#000000;stroke-width:2.0;" width="456" x="429" y="2202.1172"/><text fill="#000000" font-family="sans-serif" font-size="13" font-weight="bold" lengthAdjust="spacing" textLength="191" x="444" y="2215.6855">Repeat until full redemption</text><polygon fill="#A80036" points="834.5,2236.7383,844.5,2240.7383,834.5,2244.7383,838.5,2240.7383" style="stroke:#A80036;stroke-width:1.0;"/><line style="stroke:#A80036;stroke-width:1.0;" x1="477" x2="840.5" y1="2240.7383" y2="2240.7383"/><text fill="#000000" font-family="sans-serif" font-size="13" lengthAdjust="spacing" textLength="163" x="484" y="2235.9961">exchange bond certificate</text><polygon fill="#A80036" points="488,2266.0488,478,2270.0488,488,2274.0488,484,2270.0488" style="stroke:#A80036;stroke-width:1.0;"/><line style="stroke:#A80036;stroke-width:1.0;stroke-dasharray:2.0,2.0;" x1="482" x2="845.5" y1="2270.0488" y2="2270.0488"/><text fill="#000000" font-family="sans-serif" font-size="13" lengthAdjust="spacing" textLength="165" x="494" y="2265.3066">receive bonded BIT tokens</text><path d="M851,2297.0488 L851,2322.0488 L990,2322.0488 L990,2307.0488 L980,2297.0488 L851,2297.0488 " fill="#FBFB77" filter="url(#f1d4shlhj7bai8)" style="stroke:#A80036;stroke-width:1.0;"/><path d="M980,2297.0488 L980,2307.0488 L990,2307.0488 L980,2297.0488 " fill="#FBFB77" style="stroke:#A80036;stroke-width:1.0;"/><text fill="#000000" font-family="sans-serif" font-size="13" lengthAdjust="spacing" textLength="118" x="857" y="2314.6172">Bond balance 0 BIT</text><!--MD5=[0e8cba6204a3deaecc0b6ac17ab9cedb]
+@startuml
+'https://plantuml.com/sequence-diagram
+
+title Bonding
+
+box "(community)" #LightYellow
+actor Alice as alice
+end box
+
+box "(offchain)" #Coral
+actor Forum as forum
+end box
+
+box "(community)" #LightGray
+actor Community as community
+actor Guarantor as guarantor
+end box
+
+box "(offchain)" #Coral
+database Snapshot as snapshot
+end box
+
+box "(multisig)" #Peru
+actor BitDAOAdmin as bitdaoadmin
+end box
+
+box "(onchain)" #Lavender
+collections Bond as bond
+collections BondFactory as bondFactory
+collections GrantsTreasury as grantstreasury
+collections BitDAOTreasury as bitdaotreasury
+end box
+
+
+== Deciding funds, bond and guarantors ==
+
+alice->forum                : post outlining plan
+note right                  : 100 ETH wanted,\n150K BIT bond
+community->forum            : feedback
+guarantor->forum            : agree to guarantor
+note right                  : May have multiple guarantors
+forum- ->alice               : quorum of guarantors
+
+
+== Bond Funding ==
+
+alice->bondFactory          : request bond creation
+bondFactory->bond           : create
+bondFactory->bondFactory    : emit bond address
+bondFactory- ->alice         : bond address
+alice->forum                : bond details
+forum->guarantor            : bond address
+note left of bond           : Bond balance 0 BIT
+
+group#lightgray #white Repeats until bond target satisfied
+    guarantor->bond         : deposit bond
+    bond- ->guarantor        : receive bond certificates (tokens)
+end
+
+note left of bond           : Bond balance 150K BIT
+note left of guarantor      : Guarantors hold 150K debt certificates
+
+bond - -> alice              : Bond collateral met
+
+== Grants Treasury Funding ==
+alice -> snapshot               : submit proposal
+snapshot- ->community            : new proposal notification
+community -> snapshot           : vote on proposal
+
+group#white #LightBlue Proposal success
+    note right of grantstreasury    : Grants balance 0 ETH
+    snapshot -> bitdaoadmin         : proposal success
+    bitdaoadmin -> bitdaotreasury   : perform transfer of 100 ETH to GrantsTreasury
+    bitdaotreasury -> grantstreasury: transfer funds
+    note right of grantstreasury    : Grants balance 100 ETH
+
+else #Pink Proposal rejected
+    note left of bond               : Bond balance 150K BIT
+    snapshot -> bitdaoadmin         : proposal failed
+    bitdaoadmin -> bond             : release bond
+    bond -> bond                    : unlock BIT tokens for guarantor redemption
+    group#lightgray #white Repeat until full redemption
+        guarantor->bond             : exchange bond certificate
+        bond- ->guarantor            : receive bonded BIT tokens
+    end
+    note left of bond               : Bond balance 0 BIT
+end
+
+
+== Bond Certification Redemption ==
+
+alice->alice                    : project\ndelivery
+alice->forum                    : temperature gauge\nfor project success
+forum- ->alice                   : vote must include full payment,\npartial slashing option\nand full slashing option
+alice->snapshot                 : proposal on bond certificate redemption
+snapshot- ->community            : new proposal notification
+community -> snapshot           : vote on proposal
+snapshot -> bitdaoadmin         : proposal outcome
+
+
+note right of bond              : Bond balance 150K BIT (locked)
+
+group#white #LightBlue Full bond redemption
+    bitdaoadmin->bond           : release
+    bond->bond                  : unlock BIT tokens
+    group#lightgray #white Repeat until full redemption
+        guarantor->bond         : exchange bond certificate
+        bond- ->guarantor        : receive bonded BIT tokens
+    end
+else #Pink Full bond slash
+    bitdaoadmin->bond           : slash full bond
+    bond->bitdaotreasury        : transfer all tokens
+    bitdaotreasury- ->bond
+    note left of bitdaotreasury : balance +150K BIT
+else #lightseagreen Partial bond slashed, remaining redeemable
+    bitdaoadmin->bond           : slash partial bond
+    bond->bitdaotreasury        : transfer tokens
+    bitdaotreasury- ->bond
+    group#lightgray #white Repeat until full redemption
+        guarantor->bond         : exchange bond certificate
+        bond- ->guarantor        : receive bonded BIT tokens
+    end
+end
+
+
+note right of bond              : Bond balance 0 BIT
+
+@enduml
+
+@startuml
+
+title Bonding
+
+box "(community)" #LightYellow
+actor Alice as alice
+end box
+
+box "(offchain)" #Coral
+actor Forum as forum
+end box
+
+box "(community)" #LightGray
+actor Community as community
+actor Guarantor as guarantor
+end box
+
+box "(offchain)" #Coral
+database Snapshot as snapshot
+end box
+
+box "(multisig)" #Peru
+actor BitDAOAdmin as bitdaoadmin
+end box
+
+box "(onchain)" #Lavender
+collections Bond as bond
+collections BondFactory as bondFactory
+collections GrantsTreasury as grantstreasury
+collections BitDAOTreasury as bitdaotreasury
+end box
+
+
+== Deciding funds, bond and guarantors ==
+
+alice->forum                : post outlining plan
+note right                  : 100 ETH wanted,\n150K BIT bond
+community->forum            : feedback
+guarantor->forum            : agree to guarantor
+note right                  : May have multiple guarantors
+forum- ->alice               : quorum of guarantors
+
+
+== Bond Funding ==
+
+alice->bondFactory          : request bond creation
+bondFactory->bond           : create
+bondFactory->bondFactory    : emit bond address
+bondFactory- ->alice         : bond address
+alice->forum                : bond details
+forum->guarantor            : bond address
+note left of bond           : Bond balance 0 BIT
+
+group#lightgray #white Repeats until bond target satisfied
+    guarantor->bond         : deposit bond
+    bond- ->guarantor        : receive bond certificates (tokens)
+end
+
+note left of bond           : Bond balance 150K BIT
+note left of guarantor      : Guarantors hold 150K debt certificates
+
+bond - -> alice              : Bond collateral met
+
+== Grants Treasury Funding ==
+alice -> snapshot               : submit proposal
+snapshot- ->community            : new proposal notification
+community -> snapshot           : vote on proposal
+
+group#white #LightBlue Proposal success
+    note right of grantstreasury    : Grants balance 0 ETH
+    snapshot -> bitdaoadmin         : proposal success
+    bitdaoadmin -> bitdaotreasury   : perform transfer of 100 ETH to GrantsTreasury
+    bitdaotreasury -> grantstreasury: transfer funds
+    note right of grantstreasury    : Grants balance 100 ETH
+
+else #Pink Proposal rejected
+    note left of bond               : Bond balance 150K BIT
+    snapshot -> bitdaoadmin         : proposal failed
+    bitdaoadmin -> bond             : release bond
+    bond -> bond                    : unlock BIT tokens for guarantor redemption
+    group#lightgray #white Repeat until full redemption
+        guarantor->bond             : exchange bond certificate
+        bond- ->guarantor            : receive bonded BIT tokens
+    end
+    note left of bond               : Bond balance 0 BIT
+end
+
+
+== Bond Certification Redemption ==
+
+alice->alice                    : project\ndelivery
+alice->forum                    : temperature gauge\nfor project success
+forum- ->alice                   : vote must include full payment,\npartial slashing option\nand full slashing option
+alice->snapshot                 : proposal on bond certificate redemption
+snapshot- ->community            : new proposal notification
+community -> snapshot           : vote on proposal
+snapshot -> bitdaoadmin         : proposal outcome
+
+
+note right of bond              : Bond balance 150K BIT (locked)
+
+group#white #LightBlue Full bond redemption
+    bitdaoadmin->bond           : release
+    bond->bond                  : unlock BIT tokens
+    group#lightgray #white Repeat until full redemption
+        guarantor->bond         : exchange bond certificate
+        bond- ->guarantor        : receive bonded BIT tokens
+    end
+else #Pink Full bond slash
+    bitdaoadmin->bond           : slash full bond
+    bond->bitdaotreasury        : transfer all tokens
+    bitdaotreasury- ->bond
+    note left of bitdaotreasury : balance +150K BIT
+else #lightseagreen Partial bond slashed, remaining redeemable
+    bitdaoadmin->bond           : slash partial bond
+    bond->bitdaotreasury        : transfer tokens
+    bitdaotreasury- ->bond
+    group#lightgray #white Repeat until full redemption
+        guarantor->bond         : exchange bond certificate
+        bond- ->guarantor        : receive bonded BIT tokens
+    end
+end
+
+
+note right of bond              : Bond balance 0 BIT
+
+@enduml
+
+PlantUML version 1.2021.12(Wed Oct 06 02:01:58 AEST 2021)
+(GPL source distribution)
+Java Runtime: OpenJDK Runtime Environment
+JVM: OpenJDK 64-Bit Server VM
+Default Encoding: UTF-8
+Language: en
+Country: AU
+--></g></svg>

--- a/docs/specs/images/escrow-0.svg
+++ b/docs/specs/images/escrow-0.svg
@@ -1,0 +1,121 @@
+<?xml version="1.0" encoding="UTF-8" standalone="no"?><svg xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink" contentScriptType="application/ecmascript" contentStyleType="text/css" height="1096px" preserveAspectRatio="none" style="width:999px;height:1096px;background:#FFFFFF;" version="1.1" viewBox="0 0 999 1096" width="999px" zoomAndPan="magnify"><defs><filter height="300%" id="f1k7dm12hdi2nx" width="300%" x="-1" y="-1"><feGaussianBlur result="blurOut" stdDeviation="2.0"/><feColorMatrix in="blurOut" result="blurOut2" type="matrix" values="0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 .4 0"/><feOffset dx="4.0" dy="4.0" in="blurOut2" result="blurOut3"/><feBlend in="SourceGraphic" in2="blurOut3" mode="normal"/></filter></defs><g><text fill="#000000" font-family="sans-serif" font-size="18" lengthAdjust="spacing" textLength="171" x="416.75" y="29.4023">Escrow Token Swap</text><rect fill="#CD853F" height="1049.0508" style="stroke:#A80036;stroke-width:1.0;" width="276.5" x="16" y="41.1992"/><text fill="#000000" font-family="sans-serif" font-size="13" font-weight="bold" lengthAdjust="spacing" textLength="65" x="121.75" y="53.7676">(multisig)</text><rect fill="#E6E6FA" height="1049.0508" style="stroke:#A80036;stroke-width:1.0;" width="296" x="491.5" y="41.1992"/><text fill="#000000" font-family="sans-serif" font-size="13" font-weight="bold" lengthAdjust="spacing" textLength="64" x="607.5" y="53.7676">(onchain)</text><rect fill="#FFC0CB" filter="url(#f1k7dm12hdi2nx)" height="118.2422" style="stroke:#000000;stroke-width:2.0;" width="625.5" x="10" y="415.1719"/><rect fill="#FFC0CB" filter="url(#f1k7dm12hdi2nx)" height="176.8633" style="stroke:#000000;stroke-width:2.0;" width="625.5" x="10" y="619.0352"/><rect fill="#90EE90" filter="url(#f1k7dm12hdi2nx)" height="59.6211" style="stroke:#000000;stroke-width:2.0;" width="150" x="485.5" y="927.1406"/><line style="stroke:#A80036;stroke-width:1.0;stroke-dasharray:5.0,5.0;" x1="65" x2="65" y1="143.998" y2="1003.7617"/><line style="stroke:#A80036;stroke-width:1.0;stroke-dasharray:5.0,5.0;" x1="246.5" x2="246.5" y1="143.998" y2="1003.7617"/><line style="stroke:#A80036;stroke-width:1.0;stroke-dasharray:5.0,5.0;" x1="530.5" x2="530.5" y1="143.998" y2="1003.7617"/><line style="stroke:#A80036;stroke-width:1.0;stroke-dasharray:5.0,5.0;" x1="723.5" x2="723.5" y1="143.998" y2="1003.7617"/><text fill="#000000" font-family="sans-serif" font-size="14" lengthAdjust="spacing" textLength="85" x="20" y="141.0449">Alice_expert</text><ellipse cx="65.5" cy="70.5098" fill="#FEFECE" filter="url(#f1k7dm12hdi2nx)" rx="8" ry="8" style="stroke:#A80036;stroke-width:2.0;"/><path d="M65.5,78.5098 L65.5,105.5098 M52.5,86.5098 L78.5,86.5098 M65.5,105.5098 L52.5,120.5098 M65.5,105.5098 L78.5,120.5098 " fill="none" filter="url(#f1k7dm12hdi2nx)" style="stroke:#A80036;stroke-width:2.0;"/><text fill="#000000" font-family="sans-serif" font-size="14" lengthAdjust="spacing" textLength="85" x="20" y="1016.2969">Alice_expert</text><ellipse cx="65.5" cy="1029.25" fill="#FEFECE" filter="url(#f1k7dm12hdi2nx)" rx="8" ry="8" style="stroke:#A80036;stroke-width:2.0;"/><path d="M65.5,1037.25 L65.5,1064.25 M52.5,1045.25 L78.5,1045.25 M65.5,1064.25 L52.5,1079.25 M65.5,1064.25 L78.5,1079.25 " fill="none" filter="url(#f1k7dm12hdi2nx)" style="stroke:#A80036;stroke-width:2.0;"/><text fill="#000000" font-family="sans-serif" font-size="14" lengthAdjust="spacing" textLength="78" x="204.5" y="141.0449">Bob_expert</text><ellipse cx="246.5" cy="70.5098" fill="#FEFECE" filter="url(#f1k7dm12hdi2nx)" rx="8" ry="8" style="stroke:#A80036;stroke-width:2.0;"/><path d="M246.5,78.5098 L246.5,105.5098 M233.5,86.5098 L259.5,86.5098 M246.5,105.5098 L233.5,120.5098 M246.5,105.5098 L259.5,120.5098 " fill="none" filter="url(#f1k7dm12hdi2nx)" style="stroke:#A80036;stroke-width:2.0;"/><text fill="#000000" font-family="sans-serif" font-size="14" lengthAdjust="spacing" textLength="78" x="204.5" y="1016.2969">Bob_expert</text><ellipse cx="246.5" cy="1029.25" fill="#FEFECE" filter="url(#f1k7dm12hdi2nx)" rx="8" ry="8" style="stroke:#A80036;stroke-width:2.0;"/><path d="M246.5,1037.25 L246.5,1064.25 M233.5,1045.25 L259.5,1045.25 M246.5,1064.25 L233.5,1079.25 M246.5,1064.25 L259.5,1079.25 " fill="none" filter="url(#f1k7dm12hdi2nx)" style="stroke:#A80036;stroke-width:2.0;"/><rect fill="#FEFECE" filter="url(#f1k7dm12hdi2nx)" height="30.4883" style="stroke:#A80036;stroke-width:1.5;" width="62" x="499.5" y="104.5098"/><rect fill="#FEFECE" filter="url(#f1k7dm12hdi2nx)" height="30.4883" style="stroke:#A80036;stroke-width:1.5;" width="62" x="495.5" y="108.5098"/><text fill="#000000" font-family="sans-serif" font-size="14" lengthAdjust="spacing" textLength="48" x="502.5" y="129.0449">Escrow</text><rect fill="#FEFECE" filter="url(#f1k7dm12hdi2nx)" height="30.4883" style="stroke:#A80036;stroke-width:1.5;" width="62" x="499.5" y="1002.7617"/><rect fill="#FEFECE" filter="url(#f1k7dm12hdi2nx)" height="30.4883" style="stroke:#A80036;stroke-width:1.5;" width="62" x="495.5" y="1006.7617"/><text fill="#000000" font-family="sans-serif" font-size="14" lengthAdjust="spacing" textLength="48" x="502.5" y="1027.2969">Escrow</text><rect fill="#FEFECE" filter="url(#f1k7dm12hdi2nx)" height="30.4883" style="stroke:#A80036;stroke-width:1.5;" width="112" x="667.5" y="104.5098"/><rect fill="#FEFECE" filter="url(#f1k7dm12hdi2nx)" height="30.4883" style="stroke:#A80036;stroke-width:1.5;" width="112" x="663.5" y="108.5098"/><text fill="#000000" font-family="sans-serif" font-size="14" lengthAdjust="spacing" textLength="98" x="670.5" y="129.0449">EscrowFactory</text><rect fill="#FEFECE" filter="url(#f1k7dm12hdi2nx)" height="30.4883" style="stroke:#A80036;stroke-width:1.5;" width="112" x="667.5" y="1002.7617"/><rect fill="#FEFECE" filter="url(#f1k7dm12hdi2nx)" height="30.4883" style="stroke:#A80036;stroke-width:1.5;" width="112" x="663.5" y="1006.7617"/><text fill="#000000" font-family="sans-serif" font-size="14" lengthAdjust="spacing" textLength="98" x="670.5" y="1027.2969">EscrowFactory</text><polygon fill="#A80036" points="711.5,176.3086,721.5,180.3086,711.5,184.3086,715.5,180.3086" style="stroke:#A80036;stroke-width:1.0;"/><line style="stroke:#A80036;stroke-width:1.0;" x1="65.5" x2="717.5" y1="180.3086" y2="180.3086"/><text fill="#000000" font-family="sans-serif" font-size="13" lengthAdjust="spacing" textLength="86" x="72.5" y="175.5664">create escrow</text><path d="M728,158.998 L728,183.998 L990,183.998 L990,168.998 L980,158.998 L728,158.998 " fill="#FBFB77" filter="url(#f1k7dm12hdi2nx)" style="stroke:#A80036;stroke-width:1.0;"/><path d="M980,158.998 L980,168.998 L990,168.998 L980,158.998 " fill="#FBFB77" style="stroke:#A80036;stroke-width:1.0;"/><text fill="#000000" font-family="sans-serif" font-size="13" lengthAdjust="spacing" textLength="241" x="734" y="176.5664">party A reqmt, party B reqmt, timelock</text><line style="stroke:#A80036;stroke-width:1.0;" x1="723.5" x2="765.5" y1="214.6191" y2="214.6191"/><line style="stroke:#A80036;stroke-width:1.0;" x1="765.5" x2="765.5" y1="214.6191" y2="227.6191"/><line style="stroke:#A80036;stroke-width:1.0;" x1="724.5" x2="765.5" y1="227.6191" y2="227.6191"/><polygon fill="#A80036" points="734.5,223.6191,724.5,227.6191,734.5,231.6191,730.5,227.6191" style="stroke:#A80036;stroke-width:1.0;"/><text fill="#000000" font-family="sans-serif" font-size="13" lengthAdjust="spacing" textLength="129" x="730.5" y="209.877">emit escrow address</text><polygon fill="#A80036" points="76.5,252.9297,66.5,256.9297,76.5,260.9297,72.5,256.9297" style="stroke:#A80036;stroke-width:1.0;"/><line style="stroke:#A80036;stroke-width:1.0;" x1="70.5" x2="722.5" y1="256.9297" y2="256.9297"/><text fill="#000000" font-family="sans-serif" font-size="13" lengthAdjust="spacing" textLength="97" x="82.5" y="252.1875">escrow address</text><polygon fill="#A80036" points="518.5,282.2402,528.5,286.2402,518.5,290.2402,522.5,286.2402" style="stroke:#A80036;stroke-width:1.0;"/><line style="stroke:#A80036;stroke-width:1.0;" x1="65.5" x2="524.5" y1="286.2402" y2="286.2402"/><text fill="#000000" font-family="sans-serif" font-size="13" lengthAdjust="spacing" textLength="266" x="72.5" y="281.498">deposit eth, erc20, or nfts (party A reqmt))</text><line style="stroke:#A80036;stroke-width:1.0;" x1="530.5" x2="572.5" y1="315.5508" y2="315.5508"/><line style="stroke:#A80036;stroke-width:1.0;" x1="572.5" x2="572.5" y1="315.5508" y2="328.5508"/><line style="stroke:#A80036;stroke-width:1.0;" x1="531.5" x2="572.5" y1="328.5508" y2="328.5508"/><polygon fill="#A80036" points="541.5,324.5508,531.5,328.5508,541.5,332.5508,537.5,328.5508" style="stroke:#A80036;stroke-width:1.0;"/><text fill="#000000" font-family="sans-serif" font-size="13" lengthAdjust="spacing" textLength="179" x="537.5" y="310.8086">disallow deposits from Alice</text><polygon fill="#A80036" points="234.5,353.8613,244.5,357.8613,234.5,361.8613,238.5,357.8613" style="stroke:#A80036;stroke-width:1.0;"/><line style="stroke:#A80036;stroke-width:1.0;" x1="65.5" x2="240.5" y1="357.8613" y2="357.8613"/><text fill="#000000" font-family="sans-serif" font-size="13" lengthAdjust="spacing" textLength="90" x="72.5" y="353.1191">escrow details</text><line style="stroke:#A80036;stroke-width:1.0;" x1="65.5" x2="107.5" y1="387.1719" y2="387.1719"/><line style="stroke:#A80036;stroke-width:1.0;" x1="107.5" x2="107.5" y1="387.1719" y2="400.1719"/><line style="stroke:#A80036;stroke-width:1.0;" x1="66.5" x2="107.5" y1="400.1719" y2="400.1719"/><polygon fill="#A80036" points="76.5,396.1719,66.5,400.1719,76.5,404.1719,72.5,400.1719" style="stroke:#A80036;stroke-width:1.0;"/><text fill="#000000" font-family="sans-serif" font-size="13" lengthAdjust="spacing" textLength="167" x="72.5" y="382.4297">wait for timelock to expire</text><path d="M10,415.1719 L380,415.1719 L380,422.1719 L370,432.1719 L10,432.1719 L10,415.1719 " fill="#D3D3D3" style="stroke:#000000;stroke-width:1.0;"/><rect fill="none" height="118.2422" style="stroke:#000000;stroke-width:2.0;" width="625.5" x="10" y="415.1719"/><text fill="#000000" font-family="sans-serif" font-size="13" font-weight="bold" lengthAdjust="spacing" textLength="325" x="25" y="428.7402">if timelock expires before counterparty desposit</text><polygon fill="#A80036" points="518.5,449.793,528.5,453.793,518.5,457.793,522.5,453.793" style="stroke:#A80036;stroke-width:1.0;"/><line style="stroke:#A80036;stroke-width:1.0;" x1="65.5" x2="524.5" y1="453.793" y2="453.793"/><text fill="#000000" font-family="sans-serif" font-size="13" lengthAdjust="spacing" textLength="130" x="72.5" y="449.0508">claim Alice's deposit</text><polygon fill="#A80036" points="76.5,479.1035,66.5,483.1035,76.5,487.1035,72.5,483.1035" style="stroke:#A80036;stroke-width:1.0;"/><line style="stroke:#A80036;stroke-width:1.0;stroke-dasharray:2.0,2.0;" x1="70.5" x2="529.5" y1="483.1035" y2="483.1035"/><text fill="#000000" font-family="sans-serif" font-size="13" lengthAdjust="spacing" textLength="144" x="82.5" y="478.3613">return deposited funds</text><line style="stroke:#A80036;stroke-width:1.0;" x1="530.5" x2="572.5" y1="512.4141" y2="512.4141"/><line style="stroke:#A80036;stroke-width:1.0;" x1="572.5" x2="572.5" y1="512.4141" y2="525.4141"/><line style="stroke:#A80036;stroke-width:1.0;" x1="531.5" x2="572.5" y1="525.4141" y2="525.4141"/><polygon fill="#A80036" points="541.5,521.4141,531.5,525.4141,541.5,529.4141,537.5,525.4141" style="stroke:#A80036;stroke-width:1.0;"/><text fill="#000000" font-family="sans-serif" font-size="13" lengthAdjust="spacing" textLength="86" x="537.5" y="507.6719">delete escrow</text><polygon fill="#A80036" points="518.5,557.7246,528.5,561.7246,518.5,565.7246,522.5,561.7246" style="stroke:#A80036;stroke-width:1.0;"/><line style="stroke:#A80036;stroke-width:1.0;" x1="246.5" x2="524.5" y1="561.7246" y2="561.7246"/><text fill="#000000" font-family="sans-serif" font-size="13" lengthAdjust="spacing" textLength="260" x="253.5" y="556.9824">deposit eth, erc20, or nfts (party B reqmt)</text><line style="stroke:#A80036;stroke-width:1.0;" x1="530.5" x2="572.5" y1="591.0352" y2="591.0352"/><line style="stroke:#A80036;stroke-width:1.0;" x1="572.5" x2="572.5" y1="591.0352" y2="604.0352"/><line style="stroke:#A80036;stroke-width:1.0;" x1="531.5" x2="572.5" y1="604.0352" y2="604.0352"/><polygon fill="#A80036" points="541.5,600.0352,531.5,604.0352,541.5,608.0352,537.5,604.0352" style="stroke:#A80036;stroke-width:1.0;"/><text fill="#000000" font-family="sans-serif" font-size="13" lengthAdjust="spacing" textLength="171" x="537.5" y="586.293">disallow deposits from Bob</text><path d="M10,619.0352 L483,619.0352 L483,626.0352 L473,636.0352 L10,636.0352 L10,619.0352 " fill="#D3D3D3" style="stroke:#000000;stroke-width:1.0;"/><rect fill="none" height="176.8633" style="stroke:#000000;stroke-width:2.0;" width="625.5" x="10" y="619.0352"/><text fill="#000000" font-family="sans-serif" font-size="13" font-weight="bold" lengthAdjust="spacing" textLength="428" x="25" y="632.6035">if timelock expires and one of alice or bob have not yet claimed</text><polygon fill="#A80036" points="518.5,653.6563,528.5,657.6563,518.5,661.6563,522.5,657.6563" style="stroke:#A80036;stroke-width:1.0;"/><line style="stroke:#A80036;stroke-width:1.0;" x1="65.5" x2="524.5" y1="657.6563" y2="657.6563"/><text fill="#000000" font-family="sans-serif" font-size="13" lengthAdjust="spacing" textLength="130" x="72.5" y="652.9141">claim Alice's deposit</text><polygon fill="#A80036" points="76.5,682.9668,66.5,686.9668,76.5,690.9668,72.5,686.9668" style="stroke:#A80036;stroke-width:1.0;"/><line style="stroke:#A80036;stroke-width:1.0;stroke-dasharray:2.0,2.0;" x1="70.5" x2="529.5" y1="686.9668" y2="686.9668"/><text fill="#000000" font-family="sans-serif" font-size="13" lengthAdjust="spacing" textLength="189" x="82.5" y="682.2246">return Alice's deposited funds</text><polygon fill="#A80036" points="518.5,712.2773,528.5,716.2773,518.5,720.2773,522.5,716.2773" style="stroke:#A80036;stroke-width:1.0;"/><line style="stroke:#A80036;stroke-width:1.0;" x1="246.5" x2="524.5" y1="716.2773" y2="716.2773"/><text fill="#000000" font-family="sans-serif" font-size="13" lengthAdjust="spacing" textLength="122" x="253.5" y="711.5352">claim Bob's deposit</text><polygon fill="#A80036" points="257.5,741.5879,247.5,745.5879,257.5,749.5879,253.5,745.5879" style="stroke:#A80036;stroke-width:1.0;"/><line style="stroke:#A80036;stroke-width:1.0;stroke-dasharray:2.0,2.0;" x1="251.5" x2="529.5" y1="745.5879" y2="745.5879"/><text fill="#000000" font-family="sans-serif" font-size="13" lengthAdjust="spacing" textLength="181" x="263.5" y="740.8457">return Bob's deposited funds</text><line style="stroke:#A80036;stroke-width:1.0;" x1="530.5" x2="572.5" y1="774.8984" y2="774.8984"/><line style="stroke:#A80036;stroke-width:1.0;" x1="572.5" x2="572.5" y1="774.8984" y2="787.8984"/><line style="stroke:#A80036;stroke-width:1.0;" x1="531.5" x2="572.5" y1="787.8984" y2="787.8984"/><polygon fill="#A80036" points="541.5,783.8984,531.5,787.8984,541.5,791.8984,537.5,787.8984" style="stroke:#A80036;stroke-width:1.0;"/><text fill="#000000" font-family="sans-serif" font-size="13" lengthAdjust="spacing" textLength="86" x="537.5" y="770.1563">delete escrow</text><polygon fill="#A80036" points="518.5,820.209,528.5,824.209,518.5,828.209,522.5,824.209" style="stroke:#A80036;stroke-width:1.0;"/><line style="stroke:#A80036;stroke-width:1.0;" x1="65.5" x2="524.5" y1="824.209" y2="824.209"/><text fill="#000000" font-family="sans-serif" font-size="13" lengthAdjust="spacing" textLength="174" x="72.5" y="819.4668">claim Bob's escrowed funds</text><polygon fill="#A80036" points="76.5,849.5195,66.5,853.5195,76.5,857.5195,72.5,853.5195" style="stroke:#A80036;stroke-width:1.0;"/><line style="stroke:#A80036;stroke-width:1.0;stroke-dasharray:2.0,2.0;" x1="70.5" x2="529.5" y1="853.5195" y2="853.5195"/><text fill="#000000" font-family="sans-serif" font-size="13" lengthAdjust="spacing" textLength="137" x="82.5" y="848.7773">transfer Bob's deposit</text><polygon fill="#A80036" points="518.5,878.8301,528.5,882.8301,518.5,886.8301,522.5,882.8301" style="stroke:#A80036;stroke-width:1.0;"/><line style="stroke:#A80036;stroke-width:1.0;" x1="246.5" x2="524.5" y1="882.8301" y2="882.8301"/><text fill="#000000" font-family="sans-serif" font-size="13" lengthAdjust="spacing" textLength="182" x="253.5" y="878.0879">claim Alice's escrowed funds</text><polygon fill="#A80036" points="257.5,908.1406,247.5,912.1406,257.5,916.1406,253.5,912.1406" style="stroke:#A80036;stroke-width:1.0;"/><line style="stroke:#A80036;stroke-width:1.0;stroke-dasharray:2.0,2.0;" x1="251.5" x2="529.5" y1="912.1406" y2="912.1406"/><text fill="#000000" font-family="sans-serif" font-size="13" lengthAdjust="spacing" textLength="145" x="263.5" y="907.3984">transfer Alice's deposit</text><path d="M485.5,927.1406 L603.5,927.1406 L603.5,934.1406 L593.5,944.1406 L485.5,944.1406 L485.5,927.1406 " fill="#D3D3D3" style="stroke:#000000;stroke-width:1.0;"/><rect fill="none" height="59.6211" style="stroke:#000000;stroke-width:2.0;" width="150" x="485.5" y="927.1406"/><text fill="#000000" font-family="sans-serif" font-size="13" font-weight="bold" lengthAdjust="spacing" textLength="73" x="500.5" y="940.709">Completed</text><line style="stroke:#A80036;stroke-width:1.0;" x1="530.5" x2="572.5" y1="965.7617" y2="965.7617"/><line style="stroke:#A80036;stroke-width:1.0;" x1="572.5" x2="572.5" y1="965.7617" y2="978.7617"/><line style="stroke:#A80036;stroke-width:1.0;" x1="531.5" x2="572.5" y1="978.7617" y2="978.7617"/><polygon fill="#A80036" points="541.5,974.7617,531.5,978.7617,541.5,982.7617,537.5,978.7617" style="stroke:#A80036;stroke-width:1.0;"/><text fill="#000000" font-family="sans-serif" font-size="13" lengthAdjust="spacing" textLength="86" x="537.5" y="961.0195">delete escrow</text><!--MD5=[a160fd9e56261eead043182de6429033]
+@startuml
+'https://plantuml.com/sequence-diagram
+
+title Escrow Token Swap
+
+box "(multisig)" #Peru
+actor Alice_expert as alice
+actor Bob_expert as bob
+end box
+
+'box "(offchain)" #Coral
+'database Etherscan as etherscan
+'end box
+
+box "(onchain)" #Lavender
+collections Escrow as escrow
+collections EscrowFactory as escrowfactory
+end box
+
+alice -> escrowfactory: create escrow
+note right: party A reqmt, party B reqmt, timelock
+escrowfactory -> escrowfactory: emit escrow address
+escrowfactory -> alice: escrow address
+
+alice -> escrow: deposit eth, erc20, or nfts (party A reqmt))
+escrow -> escrow: disallow deposits from Alice
+
+alice -> bob: escrow details
+alice -> alice: wait for timelock to expire
+
+group#lightgray #pink if timelock expires before counterparty desposit
+  alice -> escrow: claim Alice's deposit
+  alice <- - escrow: return deposited funds
+  escrow -> escrow: delete escrow
+end
+
+bob -> escrow: deposit eth, erc20, or nfts (party B reqmt)
+escrow -> escrow: disallow deposits from Bob
+
+group#lightgray #pink if timelock expires and one of alice or bob have not yet claimed
+  alice -> escrow: claim Alice's deposit
+  alice <- - escrow: return Alice's deposited funds
+  bob -> escrow: claim Bob's deposit
+  bob <- - escrow: return Bob's deposited funds
+  escrow -> escrow: delete escrow
+end
+
+alice -> escrow: claim Bob's escrowed funds
+alice <- - escrow: transfer Bob's deposit
+bob -> escrow: claim Alice's escrowed funds
+bob <- - escrow: transfer Alice's deposit
+
+group#lightgray #lightgreen Completed
+escrow -> escrow: delete escrow
+end
+
+@enduml
+
+@startuml
+
+title Escrow Token Swap
+
+box "(multisig)" #Peru
+actor Alice_expert as alice
+actor Bob_expert as bob
+end box
+
+
+box "(onchain)" #Lavender
+collections Escrow as escrow
+collections EscrowFactory as escrowfactory
+end box
+
+alice -> escrowfactory: create escrow
+note right: party A reqmt, party B reqmt, timelock
+escrowfactory -> escrowfactory: emit escrow address
+escrowfactory -> alice: escrow address
+
+alice -> escrow: deposit eth, erc20, or nfts (party A reqmt))
+escrow -> escrow: disallow deposits from Alice
+
+alice -> bob: escrow details
+alice -> alice: wait for timelock to expire
+
+group#lightgray #pink if timelock expires before counterparty desposit
+  alice -> escrow: claim Alice's deposit
+  alice <- - escrow: return deposited funds
+  escrow -> escrow: delete escrow
+end
+
+bob -> escrow: deposit eth, erc20, or nfts (party B reqmt)
+escrow -> escrow: disallow deposits from Bob
+
+group#lightgray #pink if timelock expires and one of alice or bob have not yet claimed
+  alice -> escrow: claim Alice's deposit
+  alice <- - escrow: return Alice's deposited funds
+  bob -> escrow: claim Bob's deposit
+  bob <- - escrow: return Bob's deposited funds
+  escrow -> escrow: delete escrow
+end
+
+alice -> escrow: claim Bob's escrowed funds
+alice <- - escrow: transfer Bob's deposit
+bob -> escrow: claim Alice's escrowed funds
+bob <- - escrow: transfer Alice's deposit
+
+group#lightgray #lightgreen Completed
+escrow -> escrow: delete escrow
+end
+
+@enduml
+
+PlantUML version 1.2021.12(Wed Oct 06 02:01:58 AEST 2021)
+(GPL source distribution)
+Java Runtime: OpenJDK Runtime Environment
+JVM: OpenJDK 64-Bit Server VM
+Default Encoding: UTF-8
+Language: en
+Country: AU
+--></g></svg>

--- a/package.json
+++ b/package.json
@@ -20,6 +20,7 @@
     "format-ts": "prettier '**/*.ts' --write",
     "format-sol": "prettier '**/*.sol' --write",
     "lint": "eslint . --ext .ts",
+    "plant": "node ./scripts/plantuml.mjs ./docs/specs/bonding.puml",
     "prepare": "husky install",
     "test": "mocha --timeout 10000 --exit --recursive --require ts-node/register 'test/**/*.test.ts'"
   },
@@ -45,6 +46,7 @@
     "husky": "^7.0.2",
     "lint-staged": "^11.1.2",
     "mocha": "^9.1.2",
+    "node-plantuml": "github:shahankhatch/node-plantuml",
     "prettier": "^2.4.1",
     "prettier-plugin-solidity": "^1.0.0-beta.18",
     "ts-node": "^10.2.1",

--- a/package.json
+++ b/package.json
@@ -16,11 +16,12 @@
   "scripts": {
     "build": "hardhat compile",
     "clean": "hardhat clean",
-    "format": "npm run format-ts && npm run format-sol",
-    "format-ts": "prettier '**/*.ts' --write",
+    "format": "npm run format-mjs && npm run format-sol && npm run format-ts",
+    "format-mjs": "prettier '**/*.mjs' --write",
     "format-sol": "prettier '**/*.sol' --write",
+    "format-ts": "prettier '**/*.ts' --write",
     "lint": "eslint . --ext .ts",
-    "plant": "node ./scripts/plantuml.mjs ./docs/specs/bonding.puml",
+    "plant": "node ./scripts/plantuml.mjs ./docs/specs",
     "prepare": "husky install",
     "test": "mocha --timeout 10000 --exit --recursive --require ts-node/register 'test/**/*.test.ts'"
   },

--- a/scripts/plantuml.mjs
+++ b/scripts/plantuml.mjs
@@ -1,0 +1,47 @@
+import plantuml from 'node-plantuml'
+import fs from 'fs'
+import {readFile, mkdir} from 'fs/promises'
+import path from 'path'
+
+const myArgs = process.argv.slice(2)
+
+for (const arg of myArgs) {
+    const pathObj = path.parse(arg)
+
+    const content = await readFile(arg, 'utf8')
+    const len = (content.match(/newpage/g) || []).length
+
+    const targetDirectory =
+        pathObj.dir + path.sep + 'images' + path.sep + pathObj.name + path.sep
+
+    try {
+        await mkdir(targetDirectory, {recursive: true})
+    } catch (err) {
+        //  nop if directory doesn't exist
+    }
+
+    //TODO code me - get from the arg, regex for name - extension & before last slash
+    const prefix = 'myPrefix';
+
+    for (let i = 0; i <= len; i++) {
+        await generatePage(content, i, targetDirectory, prefix)
+    }
+}
+
+async function generatePage(content, page, targetDirectory, targetPrefix){
+    const generated = plantuml.generate(content, {format: 'png', pipeimageindex: page})
+
+    const outputFile =
+      targetDirectory + targetPrefix + '-plantuml-image-' + page + '.png'
+
+    console.log('starting:' + outputFile)
+
+    console.log(content.length)
+
+    generated.out.pipe(fs.createWriteStream(outputFile)).on('finish', (_) => {
+        console.log(
+          'generated image ' +
+          outputFile
+        )
+    })
+}

--- a/scripts/plantuml.mjs
+++ b/scripts/plantuml.mjs
@@ -13,13 +13,16 @@ for (const arg of myArgs) {
     console.log("PlantUml files: " + plants);
 
     for (const plant of plants) {
-      await generatePlantUmlImage(plant);
+      await renderPlantUmlDocument(plant);
     }
   } else {
-    await generatePlantUmlImage(arg);
+    await renderPlantUmlDocument(arg);
   }
 }
 
+/**
+ * Depth first recursion creating an array of all the file paths for Plant UML documents under the given directory root.
+ */
 async function recursivePlantUmlFileSearch(directory) {
   console.log("Directory " + directory);
   const files = await readdir(directory);
@@ -46,7 +49,7 @@ async function recursivePlantUmlFileSearch(directory) {
 /**
  * Creates a rendering from a Plant UML file.
  */
-async function generatePlantUmlImage(filepath) {
+async function renderPlantUmlDocument(filepath) {
   const targetFile = path.parse(filepath);
   validatePlantUmlExtensionType(targetFile.ext);
 
@@ -59,11 +62,14 @@ async function generatePlantUmlImage(filepath) {
   const targetDirectory = targetFile.dir + path.sep + "images" + path.sep;
 
   for (let i = 0; i <= len; i++) {
-    await generatePage(content, i, targetDirectory, targetFile.name);
+    await renderPage(content, i, targetDirectory, targetFile.name);
   }
 }
 
-async function generatePage(content, page, targetDirectory, targetNamePrefix) {
+/**
+ * Creates a render of a single page in a potentially multi-page Plant UML document.
+ */
+async function renderPage(content, page, targetDirectory, targetNamePrefix) {
   const generated = plantuml.generate(content, {
     format: "svg",
     pipeimageindex: page,
@@ -78,6 +84,9 @@ async function generatePage(content, page, targetDirectory, targetNamePrefix) {
   });
 }
 
+/**
+ * Recursively creates the given directory structure, quietly.
+ */
 async function createDirectoryStructure(target) {
   try {
     await mkdir(target, { recursive: true });
@@ -95,16 +104,25 @@ async function isDirectory(path) {
   return stats.isDirectory();
 }
 
-function hasPlantUmlExtension(extension) {
-  return extension.toLowerCase().endsWith(plantUmlExtension);
+/**
+ * Whether the file (path, filename or extension) has the extension that matches a Plant UML extension.
+ */
+function hasPlantUmlExtension(file) {
+  return file.toLowerCase().endsWith(plantUmlExtension);
 }
 
+/**
+ * Validates that the extension matches a Plant UML extension.
+ */
 function validatePlantUmlExtensionType(extension) {
   if (!hasPlantUmlExtension(extension)) {
     throw Error("Expecting a .puml extension, instead got: " + extension);
   }
 }
 
+/**
+ * Validates that the content is not empty, using the filepath in the error message.
+ */
 function validateNonEmptyContent(content, filepath) {
   if (content.length === 0) {
     throw Error("Content must not be empty, however not true for " + filepath);

--- a/scripts/plantuml.mjs
+++ b/scripts/plantuml.mjs
@@ -1,47 +1,59 @@
-import plantuml from 'node-plantuml'
-import fs from 'fs'
-import {readFile, mkdir} from 'fs/promises'
-import path from 'path'
+import plantuml from "node-plantuml";
+import fs from "fs";
+import { readdir, readFile, mkdir } from "fs/promises";
+import path from "path";
 
-const myArgs = process.argv.slice(2)
+const myArgs = process.argv.slice(2);
+const plantUmlExtension = ".puml";
 
 for (const arg of myArgs) {
-    const pathObj = path.parse(arg)
+  const targetFile = path.parse(arg);
+  validatePlantUmlExtensionType(targetFile.ext);
 
-    const content = await readFile(arg, 'utf8')
-    const len = (content.match(/newpage/g) || []).length
+  const content = await readFile(arg, "utf8");
+  validateNonEmptyContent(content, arg);
 
-    const targetDirectory =
-        pathObj.dir + path.sep + 'images' + path.sep + pathObj.name + path.sep
+  const len = (content.match(/newpage/g) || []).length;
 
-    try {
-        await mkdir(targetDirectory, {recursive: true})
-    } catch (err) {
-        //  nop if directory doesn't exist
-    }
+  await createDirectoryStructure(targetFile);
+  const targetDirectory = targetFile.dir + path.sep + "images" + path.sep;
 
-    //TODO code me - get from the arg, regex for name - extension & before last slash
-    const prefix = 'myPrefix';
-
-    for (let i = 0; i <= len; i++) {
-        await generatePage(content, i, targetDirectory, prefix)
-    }
+  for (let i = 0; i <= len; i++) {
+    await generatePage(content, i, targetDirectory, targetFile.name);
+  }
 }
 
-async function generatePage(content, page, targetDirectory, targetPrefix){
-    const generated = plantuml.generate(content, {format: 'png', pipeimageindex: page})
+async function generatePage(content, page, targetDirectory, targetNamePrefix) {
+  const generated = plantuml.generate(content, {
+    format: "svg",
+    pipeimageindex: page,
+  });
 
-    const outputFile =
-      targetDirectory + targetPrefix + '-plantuml-image-' + page + '.png'
+  const outputFile = targetDirectory + targetNamePrefix + "-" + page + ".svg";
 
-    console.log('starting:' + outputFile)
+  console.log("Begun generation of " + outputFile);
 
-    console.log(content.length)
+  generated.out.pipe(fs.createWriteStream(outputFile)).on("finish", (_) => {
+    console.log("Finished generation of " + outputFile);
+  });
+}
 
-    generated.out.pipe(fs.createWriteStream(outputFile)).on('finish', (_) => {
-        console.log(
-          'generated image ' +
-          outputFile
-        )
-    })
+async function createDirectoryStructure(target) {
+  try {
+    await mkdir(target, { recursive: true });
+  } catch (err) {
+    //  nop if directory doesn't exist
+  }
+}
+
+function validatePlantUmlExtensionType(extension) {
+  if (plantUmlExtension !== extension.toLowerCase()) {
+    throw Error("Expecting a .puml extension, instead got: " + extension);
+  }
+}
+
+function validateNonEmptyContent(content, filepath) {
+  if (content.length === 0) {
+    throw Error("Content must not be empty, however not true for " + filepath);
+  }
 }

--- a/scripts/plantuml.mjs
+++ b/scripts/plantuml.mjs
@@ -9,9 +9,6 @@ const plantUmlExtension = ".puml";
 for (const arg of myArgs) {
   if (await isDirectory(arg)) {
     const plants = await recursivePlantUmlFileSearch(arg);
-
-    console.log("PlantUml files: " + plants);
-
     for (const plant of plants) {
       await renderPlantUmlDocument(plant);
     }
@@ -24,7 +21,6 @@ for (const arg of myArgs) {
  * Depth first recursion creating an array of all the file paths for Plant UML documents under the given directory root.
  */
 async function recursivePlantUmlFileSearch(directory) {
-  console.log("Directory " + directory);
   const files = await readdir(directory);
   let plants = [];
 


### PR DESCRIPTION
### Purpose for this PR

<!-- Have you included adequate testing for this change? -->
Generating SVG files from PlantUML documents.

The script was based off the Treasury one, however it's been expanded to support both single file entires and a recursive search generating for all found (depending on the input) ...it's not an ironclad script, so users still have to beware (you could re-generate docs a number of times).
