### PR TITLE
fix: common Solidity pragma

### DIFF
--- a/contracts/bond/Bond.sol
+++ b/contracts/bond/Bond.sol
@@ -1,5 +1,5 @@
 // SPDX-License-Identifier: Apache-2.0
-pragma solidity ^0.8.2;
+pragma solidity ^0.8.0;
 
 import "@openzeppelin/contracts/utils/Context.sol";
 import "@openzeppelin/contracts/token/ERC20/ERC20.sol";


### PR DESCRIPTION
### Purpose for this PR

Fixing lint identified issue with '^0.8.2' being used.

<!-- Have you included adequate testing for this change? -->
```
Different versions of Solidity is used:
	- Version used: ['>=0.4.22<0.9.0', '^0.8.0', '^0.8.2']
	- ^0.8.0 (node_modules/@openzeppelin/contracts/access/Ownable.sol#3)
	- ^0.8.0 (node_modules/@openzeppelin/contracts/security/Pausable.sol#3)
	- ^0.8.0 (node_modules/@openzeppelin/contracts/token/ERC20/ERC20.sol#3)
	- ^0.8.0 (node_modules/@openzeppelin/contracts/token/ERC20/IERC20.sol#3)
	- ^0.8.0 (node_modules/@openzeppelin/contracts/token/ERC20/extensions/IERC20Metadata.sol#3)
	- ^0.8.0 (node_modules/@openzeppelin/contracts/utils/Context.sol#3)
	- ^0.8.2 (contracts/bond/Bond.sol#2)
	- ^0.8.0 (contracts/bond/BondFactory.sol#2)
	- >=0.4.22<0.9.0 (node_modules/hardhat/console.sol#2)
Reference: https://github.com/crytic/slither/wiki/Detector-Documentation#different-pragma-directives-are-used
```