### PR TITLE
fix: zero address check on parameters

### DIFF
--- a/contracts/bond/Bond.sol
+++ b/contracts/bond/Bond.sol
@@ -77,6 +77,10 @@ contract Bond is Context, ERC20, Ownable, Pausable {
         address collateralToken_,
         address treasury_
     ) ERC20(name_, symbol_) {
+        require(
+            treasury_ != address(0),
+            "Bond::constructor: treasury cannot be zero address"
+        );
         _collateralToken = IERC20Metadata(collateralToken_);
         _isRedemptionAllowed = false;
         _treasury = treasury_;
@@ -225,6 +229,10 @@ contract Bond is Context, ERC20, Ownable, Pausable {
      * @dev Permits the owner to update the treasury address, recipient of any slashed funds.
      */
     function setTreasury(address treasury_) external whenNotPaused onlyOwner {
+        require(
+            treasury_ != address(0),
+            "Bond::setTreasury: treasury cannot be zero address"
+        );
         _treasury = treasury_;
     }
 

--- a/contracts/bond/BondFactory.sol
+++ b/contracts/bond/BondFactory.sol
@@ -22,8 +22,16 @@ contract BondFactory is Context, Ownable {
     address private _collateralToken;
     address private _treasury;
 
-    constructor(address securityToken_, address treasury_) {
-        _collateralToken = securityToken_;
+    constructor(address collateralToken_, address treasury_) {
+        require(
+            collateralToken_ != address(0),
+            "BondFactory::constructor: treasury cannot be zero address"
+        );
+        require(
+            treasury_ != address(0),
+            "BondFactory::constructor: collateral token cannot be zero address"
+        );
+        _collateralToken = collateralToken_;
         _treasury = treasury_;
     }
 
@@ -47,21 +55,6 @@ contract BondFactory is Context, Ownable {
     }
 
     /**
-     * @dev Retrieves the address that receives any slashed or remaining funds.
-     */
-    function treasury() external view returns (address) {
-        return _treasury;
-    }
-
-    /**
-     * @dev Permits the owner to update the treasury address.
-     * Only applies for bonds created after the update, previously created bonds remain unchanged.
-     */
-    function setTreasury(address treasury_) external onlyOwner {
-        _treasury = treasury_;
-    }
-
-    /**
      * @dev Retrieves the address for the collateral token.
      */
     function collateralToken() external view returns (address) {
@@ -69,10 +62,33 @@ contract BondFactory is Context, Ownable {
     }
 
     /**
+     * @dev Retrieves the address that receives any slashed or remaining funds.
+     */
+    function treasury() external view returns (address) {
+        return _treasury;
+    }
+
+    /**
      * @dev Permits the owner to update the collateral token address.
      * Only applies for bonds created after the update, previously created bonds remain unchanged.
      */
     function setCollateralToken(address collateralToken_) external onlyOwner {
+        require(
+            collateralToken_ != address(0),
+            "BondFactory::setCollateralToken: treasury cannot be zero address"
+        );
         _collateralToken = collateralToken_;
+    }
+
+    /**
+     * @dev Permits the owner to update the treasury address.
+     * Only applies for bonds created after the update, previously created bonds remain unchanged.
+     */
+    function setTreasury(address treasury_) external onlyOwner {
+        require(
+            treasury_ != address(0),
+            "BondFactory::setTreasury: collateral token cannot be zero address"
+        );
+        _treasury = treasury_;
     }
 }


### PR DESCRIPTION
### Purpose for this PR

<!-- Have you included adequate testing for this change? -->
Fixes the following minor issues flagged by Slither:
```
Bond.constructor(string,string,address,address).treasury_ (contracts/bond/Bond.sol#78) lacks a zero-check on :
		- _treasury = treasury_ (contracts/bond/Bond.sol#82)
Bond.setTreasury(address).treasury_ (contracts/bond/Bond.sol#227) lacks a zero-check on :
		- _treasury = treasury_ (contracts/bond/Bond.sol#228)
BondFactory.constructor(address,address).securityToken_ (contracts/bond/BondFactory.sol#25) lacks a zero-check on :
		- _collateralToken = securityToken_ (contracts/bond/BondFactory.sol#26)
BondFactory.constructor(address,address).treasury_ (contracts/bond/BondFactory.sol#25) lacks a zero-check on :
		- _treasury = treasury_ (contracts/bond/BondFactory.sol#27)
BondFactory.setTreasury(address).treasury_ (contracts/bond/BondFactory.sol#60) lacks a zero-check on :
		- _treasury = treasury_ (contracts/bond/BondFactory.sol#61)
BondFactory.setCollateralToken(address).collateralToken_ (contracts/bond/BondFactory.sol#75) lacks a zero-check on :
		- _collateralToken = collateralToken_ (contracts/bond/BondFactory.sol#76)
Reference: https://github.com/crytic/slither/wiki/Detector-Documentation#missing-zero-address-validation
```