### PR TITLE
fix: variance in variable name

### DIFF
--- a/contracts/bond/BondFactory.sol
+++ b/contracts/bond/BondFactory.sol
@@ -72,12 +72,15 @@ contract BondFactory is Context, Ownable {
      * @dev Permits the owner to update the collateral token address.
      * Only applies for bonds created after the update, previously created bonds remain unchanged.
      */
-    function setCollateralTokens(address collateralTokens_) external onlyOwner {
+    function setCollateralTokens(address erc20CollateralTokens_)
+        external
+        onlyOwner
+    {
         require(
-            collateralTokens_ != address(0),
+            erc20CollateralTokens_ != address(0),
             "BondFactory::setCollateralTokens: collateral tokens is zero address"
         );
-        _collateralTokens = collateralTokens_;
+        _collateralTokens = erc20CollateralTokens_;
     }
 
     /**


### PR DESCRIPTION
### Purpose for this PR

<!-- Have you included adequate testing for this change? -->
Variable name too similar
```
Variable BondFactory._collateralTokens (contracts/bond/BondFactory.sol#22) is too similar to BondFactory.setCollateralTokens(address).collateralTokens_ (contracts/bond/BondFactory.sol#75)
Reference: https://github.com/crytic/slither/wiki/Detector-Documentation#variable-names-are-too-similar
```