### PR TITLE
fix: check-effects-interaction on emitted events

### DIFF
--- a/contracts/bond/Bond.sol
+++ b/contracts/bond/Bond.sol
@@ -178,13 +178,6 @@ contract Bond is Context, ERC20, Ownable, Pausable {
         uint256 redemptionAmount = _redemptionAmount(amount, totalSupply);
         _guarantorCollateral -= redemptionAmount;
 
-        // Unknown ERC20 token behaviour, cater for bool usage
-        bool transferred = _collateralTokens.transfer(
-            _msgSender(),
-            redemptionAmount
-        );
-        require(transferred, "Bond::redeem: collateral transfer failed");
-
         emit Redemption(
             _msgSender(),
             symbol(),
@@ -192,6 +185,13 @@ contract Bond is Context, ERC20, Ownable, Pausable {
             _collateralTokens.symbol(),
             redemptionAmount
         );
+
+        // Unknown ERC20 token behaviour, cater for bool usage
+        bool transferred = _collateralTokens.transfer(
+            _msgSender(),
+            redemptionAmount
+        );
+        require(transferred, "Bond::redeem: collateral transfer failed");
     }
 
     /**
@@ -222,11 +222,11 @@ contract Bond is Context, ERC20, Ownable, Pausable {
         _guarantorCollateral -= amount;
         _redemptionRatio = _calculateRedemptionRation();
 
+        emit Slash(_collateralTokens.symbol(), amount);
+
         // Unknown ERC20 token behaviour, cater for bool usage
         bool transferred = _collateralTokens.transfer(_treasury, amount);
         require(transferred, "Bond::slash: collateral transfer failed");
-
-        emit Slash(_collateralTokens.symbol(), amount);
     }
 
     /**
@@ -268,17 +268,17 @@ contract Bond is Context, ERC20, Ownable, Pausable {
             "Bond::withdrawCollateral: no collateral remain"
         );
 
+        emit WithdrawCollateral(
+            _treasury,
+            _collateralTokens.symbol(),
+            collateral
+        );
+
         // Unknown ERC20 token behaviour, cater for bool usage
         bool transferred = _collateralTokens.transfer(_treasury, collateral);
         require(
             transferred,
             "Bond::withdrawCollateral: collateral transfer failed"
-        );
-
-        emit WithdrawCollateral(
-            _treasury,
-            _collateralTokens.symbol(),
-            collateral
         );
     }
 

--- a/contracts/bond/BondFactory.sol
+++ b/contracts/bond/BondFactory.sol
@@ -41,15 +41,10 @@ contract BondFactory is Context, Ownable {
         string calldata symbol
     ) external returns (address) {
         Bond bond = new Bond(name, symbol, _collateralTokens, _treasury);
+        emit BondCreated(address(bond), name, symbol, owner(), _treasury);
+
         bond.mint(debtTokens);
         bond.transferOwnership(owner());
-        emit BondCreated(
-            address(bond),
-            name,
-            symbol,
-            bond.owner(),
-            bond.treasury()
-        );
 
         return address(bond);
     }


### PR DESCRIPTION
### Purpose for this PR

<!-- Have you included adequate testing for this change? -->
Fixes Slither lint issue about re-entrancy
```


Reentrancy in BondFactory.createBond(uint256,string,string) (contracts/bond/BondFactory.sol#38-55):
	External calls:
	- bond.mint(debtTokens) (contracts/bond/BondFactory.sol#44)
	- bond.transferOwnership(owner()) (contracts/bond/BondFactory.sol#45)
	Event emitted after the call(s):
	- BondCreated(address(bond),name,symbol,bond.owner(),bond.treasury()) (contracts/bond/BondFactory.sol#46-52)
Reentrancy in Bond.redeem(uint256) (contracts/bond/Bond.sol#167-195):
	External calls:
	- transferred = _collateralTokens.transfer(_msgSender(),redemptionAmount) (contracts/bond/Bond.sol#182-185)
	Event emitted after the call(s):
	- Redemption(_msgSender(),symbol(),amount,_collateralTokens.symbol(),redemptionAmount) (contracts/bond/Bond.sol#188-194)
Reentrancy in Bond.slash(uint256) (contracts/bond/Bond.sol#210-230):
	External calls:
	- transferred = _collateralTokens.transfer(_treasury,amount) (contracts/bond/Bond.sol#226)
	Event emitted after the call(s):
	- Slash(_collateralTokens.symbol(),amount) (contracts/bond/Bond.sol#229)
Reentrancy in Bond.withdrawCollateral() (contracts/bond/Bond.sol#254-283):
	External calls:
	- transferred = _collateralTokens.transfer(_treasury,collateral) (contracts/bond/Bond.sol#272)
	Event emitted after the call(s):
	- WithdrawCollateral(_treasury,_collateralTokens.symbol(),collateral) (contracts/bond/Bond.sol#278-282)
Reference: https://github.com/crytic/slither/wiki/Detector-Documentation#reentrancy-vulnerabilities-3
```