### PR TITLE
fix: partial collateral, full redemption of deposit

### DIFF
--- a/test/utils/events.ts
+++ b/test/utils/events.ts
@@ -106,7 +106,7 @@ export function event(name: string, events: Event[]): Event {
         if (events[i]?.event === name) return events[i]
     }
 
-    expect.fail('Failed to find event matching name: %s', name)
+    expect.fail('Failed to find event matching name: ' + name)
 }
 
 /**

--- a/test/utils/events.ts
+++ b/test/utils/events.ts
@@ -5,6 +5,7 @@ import {
     AllowRedemptionEvent,
     DebtIssueEvent,
     FullCollateralEvent,
+    PartialCollateralEvent,
     RedemptionEvent,
     SlashEvent,
     WithdrawCollateralEvent
@@ -136,6 +137,27 @@ export function fullCollateralEvent(event: Event): {
 }
 
 /**
+ * Shape check and conversion for a PartialCollateralEvent.
+ */
+export function partialCollateralEvent(event: Event): {
+    collateralSymbol: string
+    collateralAmount: BigNumber
+    debtSymbol: string
+    debtRemaining: BigNumber
+} {
+    const collateral = event as PartialCollateralEvent
+    expect(event.args).is.not.undefined
+
+    const args = event.args
+    expect(args?.collateralSymbol).is.not.undefined
+    expect(args?.collateralAmount).is.not.undefined
+    expect(args?.debtSymbol).is.not.undefined
+    expect(args?.debtRemaining).is.not.undefined
+
+    return collateral.args
+}
+
+/**
  * Shape check and conversion for a RedemptionEvent.
  */
 export function redemptionEvent(event: Event): {
@@ -239,6 +261,33 @@ export async function verifyDebtIssueEvent(
     expect(depositOneEvent.receiver, 'Debt token receiver').equals(guarantor)
     expect(depositOneEvent.debSymbol, 'Debt token symbol').equals(debt.symbol)
     expect(depositOneEvent.debtAmount, 'Debt token amount').equals(debt.amount)
+}
+
+/**
+ * Verifies the content for a Full Collateral event.
+ */
+export async function verifyPartialCollateralEvent(
+    receipt: ContractReceipt,
+    collateral: ExpectTokenBalance,
+    debt: ExpectTokenBalance
+): Promise<void> {
+    const partialCollateral = partialCollateralEvent(
+        event('PartialCollateral', events(receipt))
+    )
+    expect(
+        partialCollateral.collateralSymbol,
+        'Collateral token symbol'
+    ).equals(collateral.symbol)
+    expect(
+        partialCollateral.collateralAmount,
+        'Collateral token amount'
+    ).equals(collateral.amount)
+    expect(partialCollateral.debtSymbol, 'Debt token symbol').equals(
+        debt.symbol
+    )
+    expect(partialCollateral.debtRemaining, 'Debt tokens remaining').equals(
+        debt.amount
+    )
 }
 
 /**


### PR DESCRIPTION
### Purpose for this PR
In the use case of a bond receiving some it's expected collateral (but not all), the guarantors must be able to redeem their full deposit once it is released by the owner.

<!-- Have you included adequate testing for this change? -->
Fixes a bug where the in the partial collateral case, the guarantor were not receiving their full deposits (cause by the total supply number used in the calculation of redemption ratio).
