### PR TITLE
fix: allowing emergency flushing of funds from Bond

### DIFF
--- a/contracts/bond/Bond.sol
+++ b/contracts/bond/Bond.sol
@@ -248,8 +248,10 @@ contract Bond is Context, ERC20, Ownable, Pausable {
     }
 
     /**
-     * @dev Slashing can result in collateral remaining after full redemption due to flooring (rounding down).
-     * After full redemption, the left over collateral can be transferred to the treasury using withdrawCollateral.
+     * Allows the owner to move all the collateral held by the Bond into the Treasury.
+     *
+     * @dev Slashing can result in collateral remaining after full redemption due to flooring.
+     *      Provides an emergency extracting moving of funds out of the Bond.
      */
     function withdrawCollateral()
         external
@@ -257,11 +259,6 @@ contract Bond is Context, ERC20, Ownable, Pausable {
         whenRedeemable
         onlyOwner
     {
-        require(
-            totalSupply() == 0,
-            "Bond::withdrawCollateral: debt tokens remain"
-        );
-
         uint256 collateral = _collateralTokens.balanceOf(address(this));
         require(
             collateral > 0,

--- a/test/bond.test.ts
+++ b/test/bond.test.ts
@@ -376,19 +376,6 @@ describe('Bond contract', () => {
     })
 
     describe('withdraw collateral', () => {
-        it('cannot have outstanding Debt Tokens', async () => {
-            bond = await createBond(factory, ONE)
-            await setupGuarantorsWithCollateral([
-                {signer: guarantorOne, pledge: ONE}
-            ])
-            await depositBond(guarantorOne, ONE)
-            await allowRedemption()
-
-            await expect(bond.withdrawCollateral()).to.be.revertedWith(
-                'Bond::withdrawCollateral: debt tokens remain'
-            )
-        })
-
         it('needs collateral remaining', async () => {
             bond = await createBond(factory, ONE)
             await setupGuarantorsWithCollateral([


### PR DESCRIPTION
### Purpose for this PR

<!-- Have you included adequate testing for this change? -->
Having a guard on the withdrawal prevents using it in emergency conditions, or when there was partial collateral (e.g. bond expiry).