### PR TITLE
ci: sequential job execution

### DIFF
--- a/.github/workflows/master-push-pull.yml
+++ b/.github/workflows/master-push-pull.yml
@@ -73,7 +73,7 @@ jobs:
   Solidity-Static-Analysis:
     runs-on: ubuntu-latest
     name: Solidity static analysis
-    needs: TypeScript-Static-Analyisi
+    needs: TypeScript-Static-Analyis
     steps:
       - name: Checkout
         uses: actions/checkout@v2

--- a/.github/workflows/master-push-pull.yml
+++ b/.github/workflows/master-push-pull.yml
@@ -6,8 +6,10 @@ on:
     branches:
       - main
 
+
+
 jobs:
-  Run-Tests:
+  Unit-Tests:
     runs-on: ubuntu-latest
     name: Tests
     steps:
@@ -37,9 +39,10 @@ jobs:
         run: npm test
 
 
-  Run-Lint:
+  TypeScript-Static-Analyis:
     runs-on: ubuntu-latest
     name: TypeScript static analysis
+    needs: Unit-Tests
     steps:
       - name: Check out code
         uses: actions/checkout@v2
@@ -67,9 +70,10 @@ jobs:
         run: npm run lint
 
 
-  Slither-Analyzer:
+  Solidity-Static-Analysis:
     runs-on: ubuntu-latest
     name: Solidity static analysis
+    needs: TypeScript-Static-Analyisi
     steps:
       - name: Checkout
         uses: actions/checkout@v2


### PR DESCRIPTION
### Purpose for this PR

<!-- Have you included adequate testing for this change? -->
As caching isn't working on the first run due to race condition, making the jobs sequential _should_ solve this.

Despite the jobs running concurrently, they bottleneck with only one at a time progressing to install