### PR TITLE
docs: why collateral tokens is not settable

### DIFF
--- a/contracts/bond/Bond.sol
+++ b/contracts/bond/Bond.sol
@@ -71,6 +71,11 @@ contract Bond is Context, ERC20, Ownable, Pausable {
     address private _treasury;
     bool private _isRedemptionAllowed;
 
+    /**
+     * @param erc20CollateralTokens_ to avoid being able to break the Bond behaviours the reference to the collateral
+     *              tokens cannot be be changed after init,
+     *              To update the tokens address, either follow the proxy convention for tokens, or crete a new bond.
+     */
     constructor(
         string memory name_,
         string memory symbol_,


### PR DESCRIPTION
### Purpose for this PR

<!-- Have you included adequate testing for this change? -->
Decision to not allowing the setting of the collateral tokens was intentional, it has the potential to break the Bond operations / state.