### PR TITLE
ci: parallel after cache creation

### DIFF
--- a/.github/workflows/master-push-pull.yml
+++ b/.github/workflows/master-push-pull.yml
@@ -73,7 +73,7 @@ jobs:
   Solidity-Static-Analysis:
     runs-on: ubuntu-latest
     name: Solidity static analysis
-    needs: TypeScript-Static-Analyis
+    needs: Unit-Tests
     steps:
       - name: Checkout
         uses: actions/checkout@v2


### PR DESCRIPTION
### Purpose for this PR

<!-- Have you included adequate testing for this change? -->
Jobs were made sequential to ensure to creation of the common cache they all share (race condition, when all of them were parallel). However only one need to run first to ensure the cache creation, the remainder can be parallel.