### PR TITLE
feat: init function

### DIFF
--- a/contracts/bond/Bond.sol
+++ b/contracts/bond/Bond.sol
@@ -78,9 +78,9 @@ contract Bond is ERC20Upgradeable, OwnableUpgradeable, PausableUpgradeable {
     function initialize(
         string memory name_,
         string memory symbol_,
+        uint256 debtTokens_,
         address erc20CollateralTokens_,
-        address erc20CapableTreasury_,
-        uint256 debtTokens_
+        address erc20CapableTreasury_
     ) public initializer {
         __ERC20_init(name_, symbol_);
         __Ownable_init();

--- a/contracts/bond/Bond.sol
+++ b/contracts/bond/Bond.sol
@@ -81,7 +81,7 @@ contract Bond is ERC20Upgradeable, OwnableUpgradeable, PausableUpgradeable {
         uint256 debtTokens_,
         address erc20CollateralTokens_,
         address erc20CapableTreasury_
-    ) public initializer {
+    ) external initializer {
         __ERC20_init(name_, symbol_);
         __Ownable_init();
         __Pausable_init();

--- a/contracts/bond/Bond.sol
+++ b/contracts/bond/Bond.sol
@@ -1,18 +1,17 @@
 // SPDX-License-Identifier: Apache-2.0
 pragma solidity ^0.8.0;
 
-import "@openzeppelin/contracts/utils/Context.sol";
-import "@openzeppelin/contracts/token/ERC20/ERC20.sol";
-import "@openzeppelin/contracts/token/ERC20/extensions/IERC20Metadata.sol";
-import "@openzeppelin/contracts/access/Ownable.sol";
-import "@openzeppelin/contracts/security/Pausable.sol";
+import "@openzeppelin/contracts-upgradeable/access/OwnableUpgradeable.sol";
+import "@openzeppelin/contracts-upgradeable/token/ERC20/ERC20Upgradeable.sol";
+import "@openzeppelin/contracts-upgradeable/token/ERC20/extensions/IERC20MetadataUpgradeable.sol";
+import "@openzeppelin/contracts-upgradeable/security/PausableUpgradeable.sol";
 
 /**
  * @title Bond contract that issues debt tokens in exchange for a collateral deposited.
  *
  * @dev A single token type is held by the contract as collateral, with the Bond ERC20 token being the debt.
  */
-contract Bond is Context, ERC20, Ownable, Pausable {
+contract Bond is ERC20Upgradeable, OwnableUpgradeable, PausableUpgradeable {
     event AllowRedemption(address authorizer);
     event DebtIssue(address receiver, string debSymbol, uint256 debtAmount);
     event Deposit(
@@ -67,7 +66,7 @@ contract Bond is Context, ERC20, Ownable, Pausable {
     /// Collateral currently owed to guarantors.
     uint256 private _guarantorCollateral;
 
-    IERC20Metadata private immutable _collateralTokens;
+    IERC20MetadataUpgradeable private _collateralTokens;
     address private _treasury;
     bool private _isRedemptionAllowed;
 
@@ -76,23 +75,30 @@ contract Bond is Context, ERC20, Ownable, Pausable {
      *              tokens cannot be be changed after init,
      *              To update the tokens address, either follow the proxy convention for tokens, or crete a new bond.
      */
-    constructor(
+    function initialize(
         string memory name_,
         string memory symbol_,
         address erc20CollateralTokens_,
-        address erc20CapableTreasury_
-    ) ERC20(name_, symbol_) {
+        address erc20CapableTreasury_,
+        uint256 debtTokens_
+    ) public initializer {
+        __ERC20_init(name_, symbol_);
+        __Ownable_init();
+        __Pausable_init();
+
         require(
             erc20CapableTreasury_ != address(0),
-            "Bond::constructor: treasury is zero address"
+            "Bond::init: treasury is zero address"
         );
         require(
             erc20CollateralTokens_ != address(0),
-            "Bond::constructor: collateral tokens is zero address"
+            "Bond::init: collateral tokens is zero address"
         );
-        _collateralTokens = IERC20Metadata(erc20CollateralTokens_);
+        _collateralTokens = IERC20MetadataUpgradeable(erc20CollateralTokens_);
         _isRedemptionAllowed = false;
         _treasury = erc20CapableTreasury_;
+
+        _mint(debtTokens_);
     }
 
     /**
@@ -150,12 +156,7 @@ contract Bond is Context, ERC20, Ownable, Pausable {
     /**
      * @dev Creates additional debt tokens, inflating the supply, which without additional deposits affects the redemption ratio.
      */
-    function mint(uint256 amount)
-        external
-        whenNotPaused
-        whenNotRedeemable
-        onlyOwner
-    {
+    function _mint(uint256 amount) private whenNotPaused whenNotRedeemable {
         require(amount > 0, "Bond::mint: too small");
         _mint(address(this), amount);
     }

--- a/contracts/bond/BondFactory.sol
+++ b/contracts/bond/BondFactory.sol
@@ -11,12 +11,11 @@ import "./Bond.sol";
  * @dev Applies common configuration to bond contracts created.
  */
 contract BondFactory is Context, Ownable {
-    //TODO add debt tokens to event
-
     event BondCreated(
         address bond,
         string name,
         string symbol,
+        uint256 amount,
         address owner,
         address treasury
     );
@@ -44,7 +43,14 @@ contract BondFactory is Context, Ownable {
     ) external returns (address) {
         Bond bond = new Bond();
 
-        emit BondCreated(address(bond), name, symbol, owner(), _treasury);
+        emit BondCreated(
+            address(bond),
+            name,
+            symbol,
+            debtTokens,
+            owner(),
+            _treasury
+        );
         bond.initialize(name, symbol, debtTokens, _collateralTokens, _treasury);
         bond.transferOwnership(owner());
 

--- a/contracts/bond/BondFactory.sol
+++ b/contracts/bond/BondFactory.sol
@@ -11,6 +11,8 @@ import "./Bond.sol";
  * @dev Applies common configuration to bond contracts created.
  */
 contract BondFactory is Context, Ownable {
+    //TODO add debt tokens to event
+
     event BondCreated(
         address bond,
         string name,
@@ -36,14 +38,14 @@ contract BondFactory is Context, Ownable {
     }
 
     function createBond(
-        uint256 debtTokens,
         string calldata name,
-        string calldata symbol
+        string calldata symbol,
+        uint256 debtTokens
     ) external returns (address) {
-        Bond bond = new Bond(name, symbol, _collateralTokens, _treasury);
-        emit BondCreated(address(bond), name, symbol, owner(), _treasury);
+        Bond bond = new Bond();
 
-        bond.mint(debtTokens);
+        emit BondCreated(address(bond), name, symbol, owner(), _treasury);
+        bond.initialize(name, symbol, _collateralTokens, _treasury, debtTokens);
         bond.transferOwnership(owner());
 
         return address(bond);

--- a/contracts/bond/BondFactory.sol
+++ b/contracts/bond/BondFactory.sol
@@ -45,7 +45,7 @@ contract BondFactory is Context, Ownable {
         Bond bond = new Bond();
 
         emit BondCreated(address(bond), name, symbol, owner(), _treasury);
-        bond.initialize(name, symbol, _collateralTokens, _treasury, debtTokens);
+        bond.initialize(name, symbol, debtTokens, _collateralTokens, _treasury);
         bond.transferOwnership(owner());
 
         return address(bond);

--- a/package-lock.json
+++ b/package-lock.json
@@ -9,7 +9,8 @@
       "version": "0.0.1",
       "license": "Apache-2.0",
       "dependencies": {
-        "@openzeppelin/contracts": "^4.3.2",
+        "@openzeppelin/contracts": "^4.3.3",
+        "@openzeppelin/contracts-upgradeable": "^4.3.3",
         "bunyan": "^1.8.15"
       },
       "devDependencies": {
@@ -1483,6 +1484,11 @@
       "resolved": "https://registry.npmjs.org/@openzeppelin/contracts/-/contracts-4.3.2.tgz",
       "integrity": "sha512-AybF1cesONZStg5kWf6ao9OlqTZuPqddvprc0ky7lrUVOjXeKpmQ2Y9FK+6ygxasb+4aic4O5pneFBfwVsRRRg==",
       "dev": true
+    },
+    "node_modules/@openzeppelin/contracts-upgradeable": {
+      "version": "4.3.3",
+      "resolved": "https://registry.npmjs.org/@openzeppelin/contracts-upgradeable/-/contracts-upgradeable-4.3.3.tgz",
+      "integrity": "sha512-2ELsJkBQ0xirVQnx0utl3N+/iTPF+S0r3j0IVQIMG0HgAWreFXumY+yhGcwSV5JZ/yNNAXWR4mjIYRH/FEgu2Q=="
     },
     "node_modules/@resolver-engine/core": {
       "version": "0.3.3",
@@ -19501,6 +19507,11 @@
       "resolved": "https://registry.npmjs.org/@openzeppelin/contracts/-/contracts-4.3.2.tgz",
       "integrity": "sha512-AybF1cesONZStg5kWf6ao9OlqTZuPqddvprc0ky7lrUVOjXeKpmQ2Y9FK+6ygxasb+4aic4O5pneFBfwVsRRRg==",
       "dev": true
+    },
+    "@openzeppelin/contracts-upgradeable": {
+      "version": "4.3.3",
+      "resolved": "https://registry.npmjs.org/@openzeppelin/contracts-upgradeable/-/contracts-upgradeable-4.3.3.tgz",
+      "integrity": "sha512-2ELsJkBQ0xirVQnx0utl3N+/iTPF+S0r3j0IVQIMG0HgAWreFXumY+yhGcwSV5JZ/yNNAXWR4mjIYRH/FEgu2Q=="
     },
     "@resolver-engine/core": {
       "version": "0.3.3",

--- a/package.json
+++ b/package.json
@@ -55,6 +55,7 @@
   },
   "dependencies": {
     "bunyan": "^1.8.15",
-    "@openzeppelin/contracts": "^4.3.2"
+    "@openzeppelin/contracts": "^4.3.3",
+    "@openzeppelin/contracts-upgradeable": "^4.3.3"
   }
 }

--- a/test/bond-factory.test.ts
+++ b/test/bond-factory.test.ts
@@ -29,9 +29,10 @@ describe('BondFactory contract', () => {
     it('create bond', async () => {
         const bondName = 'Special Debt Certificate'
         const bondSymbol = 'SDC001'
+        const debtTokenAmount = 555666777n
 
         const receipt = await execute(
-            bonds.createBond(bondName, bondSymbol, 555666777n)
+            bonds.createBond(bondName, bondSymbol, debtTokenAmount)
         )
 
         const creationEvent = bondCreatedEvent(
@@ -44,6 +45,7 @@ describe('BondFactory contract', () => {
             .undefined
         expect(creationEvent.name).equals(bondName)
         expect(creationEvent.symbol).equals(bondSymbol)
+        expect(creationEvent.amount).equals(debtTokenAmount)
         expect(creationEvent.owner).equals(admin)
         expect(creationEvent.treasury).equals(treasury)
     })

--- a/test/bond-factory.test.ts
+++ b/test/bond-factory.test.ts
@@ -31,7 +31,7 @@ describe('BondFactory contract', () => {
         const bondSymbol = 'SDC001'
 
         const receipt = await execute(
-            bonds.createBond(555666777n, bondName, bondSymbol)
+            bonds.createBond(bondName, bondSymbol, 555666777n)
         )
 
         const creationEvent = bondCreatedEvent(

--- a/test/bond.test.ts
+++ b/test/bond.test.ts
@@ -143,9 +143,9 @@ describe('Bond contract', () => {
                 bond.initialize(
                     'My Debt Tokens one',
                     'MDT001',
+                    ONE,
                     collateral.address,
-                    treasury,
-                    ONE
+                    treasury
                 )
             ).to.be.revertedWith(
                 'Initializable: contract is already initialized'
@@ -159,9 +159,9 @@ describe('Bond contract', () => {
                 bond.initialize(
                     'My Debt Tokens two',
                     'MDT002',
+                    ZERO,
                     collateral.address,
-                    treasury,
-                    ZERO
+                    treasury
                 )
             ).to.be.revertedWith('Bond::mint: too small')
         })
@@ -173,9 +173,9 @@ describe('Bond contract', () => {
                 bond.initialize(
                     'My Debt Tokens two',
                     'MDT002',
+                    ONE,
                     collateral.address,
-                    ADDRESS_ZERO,
-                    ONE
+                    ADDRESS_ZERO
                 )
             ).to.be.revertedWith('Bond::init: treasury is zero address')
         })
@@ -187,9 +187,9 @@ describe('Bond contract', () => {
                 bond.initialize(
                     'My Debt Tokens two',
                     'MDT002',
+                    ONE,
                     ADDRESS_ZERO,
-                    treasury,
-                    ONE
+                    treasury
                 )
             ).to.be.revertedWith(
                 'Bond::init: collateral tokens is zero address'

--- a/test/utils/events.ts
+++ b/test/utils/events.ts
@@ -57,6 +57,7 @@ export function bondCreatedEvent(event: Event): {
     bond: string
     name: string
     symbol: string
+    amount: BigNumber
     owner: string
     treasury: string
 } {
@@ -67,6 +68,7 @@ export function bondCreatedEvent(event: Event): {
     expect(args?.bond).is.not.undefined
     expect(args?.name).is.not.undefined
     expect(args?.symbol).is.not.undefined
+    expect(args?.amount).is.not.undefined
     expect(args?.owner).is.not.undefined
     expect(args?.treasury).is.not.undefined
 


### PR DESCRIPTION
### Purpose for this PR

Converting the Bond contract over to using an init function, instead of the constructor for initialisation.

While this is the groundwork for upgradability (if deployed with a proxy), it also can facilitate cloning. When deployed from a contract (i.e. BondContract) additional care would be needed if using a proxy pattern (due to proxy ownership behaviour).

<!-- Have you included adequate testing for this change? -->
Closes https://github.com/windranger-io/windranger-treasury/issues/15