### PR TITLE
fix: Solhint enforced Solidity styling

### DIFF
--- a/.solhint.json
+++ b/.solhint.json
@@ -2,13 +2,34 @@
   "extends": "solhint:recommended",
   "plugins": [],
   "rules": {
+    "no-unused-vars": "error",
+    "payable-fallback": "error",
+    "reason-string": "error",
+    "constructor-syntax": "error",
+
+    "const-name-snakecase": "error",
+    "contract-name-camelcase": "error",
+    "event-name-camelcase": "error",
+    "func-name-mixedcase": "error",
+    "func-param-name-mixedcase": "error",
+    "modifier-name-mixedcase": "error",
+    "private-vars-leading-underscore": "error",
+    "use-forbidden-name": "error",
+    "var-name-mixedcase": "error",
+    "func-order": "error",
+    "imports-on-top": "error",
+    "ordering": "error",
+    "visibility-modifier-order": "error",
+
+    "avoid-call-value": "error",
+    "avoid-sha3": "error",
     "avoid-suicide": "error",
-    "avoid-sha3": "warn",
+    "avoid-throw": "error",
+    "avoid-tx-origin": "error",
+    "func-visibility": "error",
+    "state-visibility": "error",
+
     "not-rely-on-time": "off",
-    "constructor-syntax": "warn",
-    "func-param-name-mixedcase": "warn",
-    "modifier-name-mixedcase": "warn",
-    "private-vars-leading-underscore": "warn",
     "compiler-version": "off"
   }
 }

--- a/.solhint.json
+++ b/.solhint.json
@@ -10,13 +10,11 @@
     "const-name-snakecase": "error",
     "contract-name-camelcase": "error",
     "event-name-camelcase": "error",
-    "func-name-mixedcase": "error",
     "func-param-name-mixedcase": "error",
     "modifier-name-mixedcase": "error",
     "private-vars-leading-underscore": "error",
     "use-forbidden-name": "error",
     "var-name-mixedcase": "error",
-    "func-order": "error",
     "imports-on-top": "error",
     "ordering": "error",
     "visibility-modifier-order": "error",
@@ -26,10 +24,12 @@
     "avoid-suicide": "error",
     "avoid-throw": "error",
     "avoid-tx-origin": "error",
-    "func-visibility": "error",
+    "func-visibility": ["error", { "ignoreConstructors": true }],
     "state-visibility": "error",
 
     "not-rely-on-time": "off",
-    "compiler-version": "off"
+    "compiler-version": "off",
+    "no-empty-blocks": "off",
+    "func-name-mixedcase": "off"
   }
 }

--- a/contracts/bond/ExpiryTimestamp.sol
+++ b/contracts/bond/ExpiryTimestamp.sol
@@ -11,6 +11,8 @@ import "@openzeppelin/contracts-upgradeable/proxy/utils/Initializable.sol";
           is after  the expiry timestamp.
  */
 abstract contract ExpiryTimestamp is Initializable {
+    uint256 private _expiry;
+
     /**
         @notice Reverts when the time has not met or passed the expiry timestamp.
      */
@@ -18,8 +20,6 @@ abstract contract ExpiryTimestamp is Initializable {
         require(block.timestamp >= _expiry, "ExpiryTimestamp: not yet expired");
         _;
     }
-
-    uint256 private _expiry;
 
     /**
         @notice Initialisation of the expiry timestamp to enable the 'hasExpired' modifier.

--- a/contracts/test/Box.sol
+++ b/contracts/test/Box.sol
@@ -7,9 +7,9 @@ pragma solidity ^0.8.0;
     @dev Event emitted on storing the value.
  */
 contract Box {
-    event Store(string value);
-
     string private _value;
+
+    event Store(string value);
 
     /**
         @notice store the given value.

--- a/test/bond-factory.test.ts
+++ b/test/bond-factory.test.ts
@@ -34,9 +34,7 @@ describe('BondFactory contract', () => {
         it('non-whitelisted collateral', async () => {
             await expect(
                 bonds.createBond('Named bond', 'AA00AA', 101n, 'BEEP', 0n, '')
-            ).to.be.revertedWith(
-                'BondFactory::bond: collateral not whitelisted'
-            )
+            ).to.be.revertedWith('BF: collateral not whitelisted')
         })
 
         it('whitelisted (BIT) collateral', async () => {
@@ -97,17 +95,13 @@ describe('BondFactory contract', () => {
         it('cannot update address with identical value', async () => {
             await expect(
                 bonds.updateCollateralTokenAddress(collateralTokens.address)
-            ).to.be.revertedWith(
-                'BondFactory::updateCollateralTokenAddress: same address'
-            )
+            ).to.be.revertedWith('BF: collateral identical address')
         })
 
         it('cannot update address to zero', async () => {
             await expect(
                 bonds.updateCollateralTokenAddress(ADDRESS_ZERO)
-            ).to.be.revertedWith(
-                'BondFactory::updateCollateralTokenAddress: collateral tokens is zero address'
-            )
+            ).to.be.revertedWith('BF: collateral is zero address')
         })
 
         it('cannot update address to non-contract address', async () => {
@@ -146,13 +140,13 @@ describe('BondFactory contract', () => {
         it('cannot add existing token', async () => {
             await expect(
                 bonds.whitelistCollateralToken(collateralTokens.address)
-            ).to.be.revertedWith('BondFactory::whitelist: already present')
+            ).to.be.revertedWith('BF: whitelist already present')
         })
 
         it('cannot add address zero', async () => {
             await expect(
                 bonds.whitelistCollateralToken(ADDRESS_ZERO)
-            ).to.be.revertedWith('BondFactory::whitelist: address zero')
+            ).to.be.revertedWith('BF: whitelist is zero address')
         })
 
         it('cannot add non-erc20 contract (without fallback)', async () => {

--- a/test/bond.test.ts
+++ b/test/bond.test.ts
@@ -82,7 +82,7 @@ describe('Bond contract', () => {
             await bond.allowRedemption()
 
             await expect(bond.allowRedemption()).to.be.revertedWith(
-                'Bond::whenNotRedeemable: redeemable'
+                'whenNotRedeemable: redeemable'
             )
         })
 
@@ -100,7 +100,7 @@ describe('Bond contract', () => {
             bond = await createBond(factory, 5566777n)
 
             await expect(bond.deposit(ZERO)).to.be.revertedWith(
-                'Bond::deposit: too small'
+                'Bond: too small'
             )
         })
 
@@ -109,7 +109,7 @@ describe('Bond contract', () => {
             bond = await createBond(factory, debtTokens)
 
             await expect(bond.deposit(debtTokens + 1n)).to.be.revertedWith(
-                'Bond::deposit: too large'
+                'Bond: too large'
             )
         })
 
@@ -136,7 +136,7 @@ describe('Bond contract', () => {
 
             await expect(
                 bond.connect(guarantorOne).deposit(pledge)
-            ).to.be.revertedWith('Bond::whenNotRedeemable: redeemable')
+            ).to.be.revertedWith('whenNotRedeemable: redeemable')
         })
 
         it('with full collateral', async () => {
@@ -220,7 +220,7 @@ describe('Bond contract', () => {
 
             await expect(
                 bond.connect(guarantorOne).expire()
-            ).to.be.revertedWith('Bond::expire: no collateral remains')
+            ).to.be.revertedWith('Bond: no collateral remains')
         })
 
         it('only after expiry', async () => {
@@ -292,7 +292,7 @@ describe('Bond contract', () => {
                     BOND_EXPIRY,
                     DATA
                 )
-            ).to.be.revertedWith('Bond::init: treasury is zero address')
+            ).to.be.revertedWith('Bond: treasury is zero address')
         })
 
         it('collateral tokens address cannot be zero', async () => {
@@ -308,9 +308,7 @@ describe('Bond contract', () => {
                     BOND_EXPIRY,
                     DATA
                 )
-            ).to.be.revertedWith(
-                'Bond::init: collateral tokens is zero address'
-            )
+            ).to.be.revertedWith('Bond: collateral is zero address')
         })
 
         it('initial debt tokens are recorded', async () => {
@@ -387,7 +385,7 @@ describe('Bond contract', () => {
             await allowRedemption()
 
             await expect(redeem(guarantorOne, ZERO)).to.be.revertedWith(
-                'Bond::redeem: too small'
+                'Bond: too small'
             )
         })
 
@@ -401,7 +399,7 @@ describe('Bond contract', () => {
 
             await expect(
                 bond.connect(guarantorOne).redeem(pledge)
-            ).to.be.revertedWith('Bond::whenRedeemable: not redeemable')
+            ).to.be.revertedWith('whenRedeemable: not redeemable')
         })
 
         it('only when not paused', async () => {
@@ -455,9 +453,7 @@ describe('Bond contract', () => {
             ])
             await depositBond(guarantorOne, pledge)
 
-            await expect(bond.slash(ZERO)).to.be.revertedWith(
-                'Bond::slash: too small'
-            )
+            await expect(bond.slash(ZERO)).to.be.revertedWith('Bond: too small')
         })
 
         it('cannot be greater than collateral held', async () => {
@@ -469,7 +465,7 @@ describe('Bond contract', () => {
             await depositBond(guarantorOne, pledge)
 
             await expect(bond.slash(pledge + 1n)).to.be.revertedWith(
-                'Bond::slash: greater than available collateral'
+                'Bond: too large'
             )
         })
 
@@ -483,7 +479,7 @@ describe('Bond contract', () => {
             await allowRedemption()
 
             await expect(bond.slash(pledge)).to.be.revertedWith(
-                'Bond::whenNotRedeemable: redeemable'
+                'whenNotRedeemable: redeemable'
             )
         })
 
@@ -568,7 +564,7 @@ describe('Bond contract', () => {
             await redeem(guarantorOne, ONE)
 
             await expect(bond.withdrawCollateral()).to.be.revertedWith(
-                'Bond::withdrawCollateral: no collateral remain'
+                'Bond: no collateral remains'
             )
         })
 
@@ -586,7 +582,7 @@ describe('Bond contract', () => {
             bond = await createBond(factory, ONE)
 
             await expect(bond.withdrawCollateral()).to.be.revertedWith(
-                'Bond::whenRedeemable: not redeemable'
+                'whenRedeemable: not redeemable'
             )
         })
 


### PR DESCRIPTION
### Purpose for this PR

<!-- Have you included adequate testing for this change? -->
Bumped up the Solhint warning to errors to enforce code style in the Solidity (Solidity specific style, beyond the general Prettier-Solidity plugin)
