### PR TITLE
fix: no collateral transfer when amount is zero

### DIFF
--- a/contracts/bond/Bond.sol
+++ b/contracts/bond/Bond.sol
@@ -241,12 +241,15 @@ contract Bond is
 
         _burn(_msgSender(), amount);
 
+        // Slashing can reduce redemption amount to zero
+        if(redemptionAmount > 0){
         // Unknown ERC20 token behaviour, cater for bool usage
         bool transferred = _collateralTokens.transfer(
             _msgSender(),
             redemptionAmount
         );
         require(transferred, "Bond: collateral transfer failed");
+        }
     }
 
     /**

--- a/contracts/bond/Bond.sol
+++ b/contracts/bond/Bond.sol
@@ -242,13 +242,13 @@ contract Bond is
         _burn(_msgSender(), amount);
 
         // Slashing can reduce redemption amount to zero
-        if(redemptionAmount > 0){
-        // Unknown ERC20 token behaviour, cater for bool usage
-        bool transferred = _collateralTokens.transfer(
-            _msgSender(),
-            redemptionAmount
-        );
-        require(transferred, "Bond: collateral transfer failed");
+        if (redemptionAmount > 0) {
+            // Unknown ERC20 token behaviour, cater for bool usage
+            bool transferred = _collateralTokens.transfer(
+                _msgSender(),
+                redemptionAmount
+            );
+            require(transferred, "Bond: collateral transfer failed");
         }
     }
 


### PR DESCRIPTION
### Purpose for this PR
<!-- Have you included adequate testing for this change? -->

This saves on making a transfer, when redeeming if there is no value to transfer (`uint amount == 0`).

It bring the behaviour inline with the Bond's guards against trying to deposit, redeem or slash zero amounts, while also saving the gas cost for a guarantor who redeems and will get back none of their collateral (due to slashing). 

In theory, preventing a transfer when the value is zero also avoids the risk of interacting with the ERC20 contract who's behaviour is to revert in that case.