### PR TITLE
fix: OZ contracts as dev dependencies

### DIFF
--- a/package.json
+++ b/package.json
@@ -30,6 +30,7 @@
     "@nomiclabs/hardhat-ethers": "^2.0.2",
     "@nomiclabs/hardhat-waffle": "^2.0.1",
     "@openzeppelin/contracts": "^4.3.3",
+    "@openzeppelin/contracts-upgradeable": "^4.3.3",
     "@typechain/ethers-v5": "^7.0.1",
     "@typechain/hardhat": "^2.3.0",
     "@types/bunyan": "^1.8.7",
@@ -58,8 +59,6 @@
     "typescript": "^4.4.2"
   },
   "dependencies": {
-    "@openzeppelin/contracts": "^4.3.3",
-    "@openzeppelin/contracts-upgradeable": "^4.3.3",
     "bunyan": "^1.8.15"
   }
 }


### PR DESCRIPTION
### Purpose for this PR
The OZ contract are only required during the build phase. After contract compilation (generation of the deployable byte code) they are not required.

<!-- Have you included adequate testing for this change? -->
