### PR TITLE
fix: aligning parameter name with convention

### DIFF
--- a/contracts/test/Box.sol
+++ b/contracts/test/Box.sol
@@ -16,8 +16,8 @@ contract Box {
         @dev storing the value causes the Store event to be emitted, overwriting any previously stored value.
         @param boxValue_ value for storage in the Box, no restrictions.
      */
-    function store(string calldata boxValue_) external {
-        _value = boxValue_;
+    function store(string calldata boxValue) external {
+        _value = boxValue;
 
         emit Store(_value);
     }

--- a/contracts/test/Box.sol
+++ b/contracts/test/Box.sol
@@ -14,7 +14,7 @@ contract Box {
     /**
         @notice store the given value.
         @dev storing the value causes the Store event to be emitted, overwriting any previously stored value.
-        @param boxValue_ value for storage in the Box, no restrictions.
+        @param boxValue value for storage in the Box, no restrictions.
      */
     function store(string calldata boxValue) external {
         _value = boxValue;


### PR DESCRIPTION
### Purpose for this PR
No underscores in parameter names.
<!-- Have you included adequate testing for this change? -->
