### PR TITLE
ci: renovate instead of dependabot for npm

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -5,7 +5,3 @@ updates:
     directory: "/"
     schedule:
       interval: "weekly"
-  - package-ecosystem: "npm"
-    directory: "/"
-    schedule:
-      interval: "monthly"

--- a/renovate.json
+++ b/renovate.json
@@ -1,0 +1,11 @@
+{
+  "extends": ["config:base", "group:all", "schedule:monthly"],
+  "assigneesFromCodeOwners": true,
+  "assigneesSampleSize": 1,
+  "packageRules": [
+    {
+      "matchUpdateTypes": ["pin", "digest", "lockFileMaintenance"],
+      "enabled": false
+    }
+  ]
+}


### PR DESCRIPTION
### Purpose for this PR
Replacing Dependabot for Renovate to have a single PR raised, instead of one per a changed dependency. 
<!-- Have you included adequate testing for this change? -->
