### PR TITLE
ci: slither config file with npm caching

### DIFF
--- a/.github/workflows/main-push-pull.yml
+++ b/.github/workflows/main-push-pull.yml
@@ -117,7 +117,21 @@ jobs:
           restore-keys: |
             ${{ runner.os }}-node-
 
-      - name: Slither Static Analysis
-        uses: luisfontes19/slither-static-analysis-action@v0.3.4
+      - name: Set up node
+        uses: actions/setup-node@v2.5.1
         with:
-          slither-params: '--filter-paths "contracts/test|contracts/treasury|node_modules" --exclude solc-version'
+          node-version: '16'
+
+      - name: Install dependencies
+        run: npm ci
+
+      - uses: actions/setup-python@v2
+        with:
+          python-version: '3.x'
+          architecture: 'x64'
+
+      - name: Install Slither
+        run: pip3 install slither-analyzer
+
+      - name: Slither Static Analysis
+        run: slither . --config-file slither.json

--- a/README.md
+++ b/README.md
@@ -158,5 +158,6 @@ slither . --filter-paths "BitDAO.sol|contracts/treasury|node_modules"
 Alternatively to run using a `slither.json` config file:
 
 ```shell
+cd test-me
 slither . --config-file slither.json
 ```

--- a/README.md
+++ b/README.md
@@ -120,6 +120,12 @@ When at the project root, to run and exclude `BitDao.sol`, anything containing t
 slither . --filter-paths "BitDAO.sol|contracts/treasury|node_modules"
 ```
 
+Alternatively to run using a `slither.json` config file:
+
+```shell
+slither . --config-file slither.json
+```
+
 ### Docker
 
 The Trail of Bits toolbox image contains a number of applications (including Slither).
@@ -147,4 +153,10 @@ Navigate into the `test-me` directory and run the static analysis:
 ```shell
 cd test-me
 slither . --filter-paths "BitDAO.sol|contracts/treasury|node_modules"
+```
+
+Alternatively to run using a `slither.json` config file:
+
+```shell
+slither . --config-file slither.json
 ```

--- a/slither.json
+++ b/slither.json
@@ -1,0 +1,10 @@
+{
+  "detectors_to_exclude": "solc-version,naming-convention",
+  "exclude_informational": false,
+  "exclude_low": false,
+  "exclude_medium": false,
+  "exclude_high": false,
+  "disable_color": false,
+  "filter_paths": "contracts/test|contracts/treasury|node_modules",
+  "legacy_ast": false
+}


### PR DESCRIPTION
### Purpose for this PR
The Slither CI task now uses the npm cache and takes the settings form the `slither.json` config file (instead of cmd line)
<!-- Have you included adequate testing for this change? -->
