### PR TITLE
feat: Multiple admin support

### DIFF
--- a/contracts/bond/BondFactory.sol
+++ b/contracts/bond/BondFactory.sol
@@ -168,6 +168,7 @@ contract BondFactory is
 
         _treasury = erc20CapableTreasury;
 
+        _setRoleAdmin(Roles.BOND_ADMIN, Roles.DAO_ADMIN);
         _setRoleAdmin(Roles.SYSTEM_ADMIN, Roles.DAO_ADMIN);
         _setupRole(Roles.DAO_ADMIN, _msgSender());
         _setupRole(Roles.SYSTEM_ADMIN, _msgSender());

--- a/contracts/bond/BondFactory.sol
+++ b/contracts/bond/BondFactory.sol
@@ -14,9 +14,9 @@ import "./Roles.sol";
  * @dev Uses common configuration when creating bond contracts.
  */
 contract BondFactory is
+    AccessControlUpgradeable,
     BondCreator,
     CollateralWhitelist,
-    AccessControlUpgradeable,
     UUPSUpgradeable
 {
     address private _treasury;

--- a/contracts/bond/BondFactory.sol
+++ b/contracts/bond/BondFactory.sol
@@ -1,11 +1,12 @@
 // SPDX-License-Identifier: Apache-2.0
 pragma solidity ^0.8.0;
 
-import "@openzeppelin/contracts-upgradeable/access/OwnableUpgradeable.sol";
+import "@openzeppelin/contracts-upgradeable/access/AccessControlUpgradeable.sol";
 import "@openzeppelin/contracts-upgradeable/proxy/utils/UUPSUpgradeable.sol";
 import "./CollateralWhitelist.sol";
 import "./ERC20SingleCollateralBond.sol";
 import "./BondCreator.sol";
+import "./Roles.sol";
 
 /**
  * @title Creates Bond contracts.
@@ -15,7 +16,7 @@ import "./BondCreator.sol";
 contract BondFactory is
     BondCreator,
     CollateralWhitelist,
-    OwnableUpgradeable,
+    AccessControlUpgradeable,
     UUPSUpgradeable
 {
     address private _treasury;
@@ -25,7 +26,7 @@ contract BondFactory is
         string name,
         string debtSymbol,
         uint256 debtAmount,
-        address owner,
+        address creator,
         address treasury,
         uint256 expiryTimestamp,
         uint256 minimumDeposit,
@@ -66,7 +67,7 @@ contract BondFactory is
             name,
             symbol,
             debtTokens,
-            owner(),
+            _msgSender(),
             _treasury,
             expiryTimestamp,
             minimumDeposit,
@@ -93,7 +94,10 @@ contract BondFactory is
      *
      * @dev Only applies for bonds created after the update, previously created bond treasury addresses remain unchanged.
      */
-    function setTreasury(address replacement) external onlyOwner {
+    function setTreasury(address replacement)
+        external
+        onlyRole(Roles.BOND_ADMIN)
+    {
         require(replacement != address(0), "BF: treasury is zero address");
         require(_treasury != replacement, "BF: treasury address identical");
         _treasury = replacement;
@@ -108,7 +112,7 @@ contract BondFactory is
      */
     function updateWhitelistedCollateral(address erc20CollateralTokens)
         external
-        onlyOwner
+        onlyRole(Roles.BOND_ADMIN)
     {
         _updateWhitelistedCollateral(erc20CollateralTokens);
     }
@@ -122,7 +126,7 @@ contract BondFactory is
      */
     function removeWhitelistedCollateral(string calldata symbol)
         external
-        onlyOwner
+        onlyRole(Roles.BOND_ADMIN)
     {
         _removeWhitelistedCollateral(symbol);
     }
@@ -137,7 +141,7 @@ contract BondFactory is
      */
     function whitelistCollateral(address erc20CollateralTokens)
         external
-        onlyOwner
+        onlyRole(Roles.BOND_ADMIN)
     {
         _whitelistCollateral(erc20CollateralTokens);
     }
@@ -146,11 +150,15 @@ contract BondFactory is
         return _treasury;
     }
 
+    /**
+     * @notice The _msgSender() is given membership of all roles, to allow granting and future renouncing after others
+     *      have been setup.
+     */
     function __BondFactory_init(
         address erc20CollateralTokens,
         address erc20CapableTreasury
     ) internal onlyInitializing {
-        __Ownable_init();
+        __AccessControl_init();
         __CollateralWhitelist_init();
 
         require(
@@ -159,6 +167,11 @@ contract BondFactory is
         );
 
         _treasury = erc20CapableTreasury;
+
+        _setRoleAdmin(Roles.SYSTEM_ADMIN, Roles.DAO_ADMIN);
+        _setupRole(Roles.DAO_ADMIN, _msgSender());
+        _setupRole(Roles.SYSTEM_ADMIN, _msgSender());
+        _setupRole(Roles.BOND_ADMIN, _msgSender());
 
         _whitelistCollateral(erc20CollateralTokens);
     }
@@ -171,6 +184,6 @@ contract BondFactory is
     function _authorizeUpgrade(address newImplementation)
         internal
         override
-        onlyOwner
+        onlyRole(Roles.SYSTEM_ADMIN)
     {}
 }

--- a/contracts/bond/BondManager.sol
+++ b/contracts/bond/BondManager.sol
@@ -40,12 +40,13 @@ contract BondManager is
         onlyRole(Roles.BOND_AGGREGATOR)
     {
         require(!_bonds.contains(bond), "BondManager: already managing");
+
+        emit AddBond(bond);
+
         require(
             OwnableUpgradeable(bond).owner() == address(this),
             "BondManager: not bond owner"
         );
-
-        emit AddBond(bond);
 
         bool added = _bonds.add(bond);
         require(added, "BondManager: failed to add");

--- a/contracts/bond/BondManager.sol
+++ b/contracts/bond/BondManager.sol
@@ -134,6 +134,8 @@ contract BondManager is
         __AccessControl_init();
         __Pausable_init();
 
+        _setRoleAdmin(Roles.BOND_ADMIN, Roles.DAO_ADMIN);
+        _setRoleAdmin(Roles.BOND_AGGREGATOR, Roles.DAO_ADMIN);
         _setRoleAdmin(Roles.SYSTEM_ADMIN, Roles.DAO_ADMIN);
         _setupRole(Roles.DAO_ADMIN, _msgSender());
         _setupRole(Roles.SYSTEM_ADMIN, _msgSender());

--- a/contracts/bond/BondManager.sol
+++ b/contracts/bond/BondManager.sol
@@ -33,8 +33,12 @@ contract BondManager is
 
     event AddBond(address bond);
 
-    //TODO add permission guard - need to figure out single control model across three contracts
-    function addBond(address bond) external override whenNotPaused {
+    function addBond(address bond)
+        external
+        override
+        whenNotPaused
+        onlyRole(Roles.BOND_AGGREGATOR)
+    {
         require(!_bonds.contains(bond), "BondManager: already managing");
         require(
             OwnableUpgradeable(bond).owner() == address(this),
@@ -134,6 +138,7 @@ contract BondManager is
         _setupRole(Roles.DAO_ADMIN, _msgSender());
         _setupRole(Roles.SYSTEM_ADMIN, _msgSender());
         _setupRole(Roles.BOND_ADMIN, _msgSender());
+        _setupRole(Roles.BOND_AGGREGATOR, _msgSender());
     }
 
     /**

--- a/contracts/bond/BondMediator.sol
+++ b/contracts/bond/BondMediator.sol
@@ -1,11 +1,16 @@
 // SPDX-License-Identifier: Apache-2.0
 pragma solidity ^0.8.0;
 
+import "@openzeppelin/contracts-upgradeable/access/AccessControlUpgradeable.sol";
 import "@openzeppelin/contracts-upgradeable/utils/AddressUpgradeable.sol";
-import "@openzeppelin/contracts-upgradeable/access/OwnableUpgradeable.sol";
 import "@openzeppelin/contracts-upgradeable/proxy/utils/UUPSUpgradeable.sol";
 import "./BondCreator.sol";
 import "./BondCurator.sol";
+import "./Roles.sol";
+
+interface OwnableUpgradeable {
+    function transferOwnership(address newOwner) external;
+}
 
 /**
  * @title Mediates between a Bond creator and Bond curator.
@@ -13,11 +18,14 @@ import "./BondCurator.sol";
  * @dev Orchestrates a BondCreator and BondCurator to provide a single function to aggregate the various calls
  *      providing a single function to create and setup a bond for management with the curator.
  */
-contract BondMediator is OwnableUpgradeable, UUPSUpgradeable {
+contract BondMediator is AccessControlUpgradeable, UUPSUpgradeable {
     BondCreator private _creator;
     BondCurator private _curator;
 
     /**
+     * @notice The _msgSender() is given membership of all roles, to allow granting and future renouncing after others
+     *      have been setup.
+     *
      * @param factory A deployed BondCreator contract to use when creating bonds.
      * @param manager A deployed BondCurator contract to register created bonds with,
      */
@@ -35,10 +43,15 @@ contract BondMediator is OwnableUpgradeable, UUPSUpgradeable {
             "Mediator: curator not a contract"
         );
 
-        __Ownable_init();
+        __AccessControl_init();
 
         _creator = BondCreator(factory);
         _curator = BondCurator(manager);
+
+        _setRoleAdmin(Roles.SYSTEM_ADMIN, Roles.DAO_ADMIN);
+        _setupRole(Roles.DAO_ADMIN, _msgSender());
+        _setupRole(Roles.SYSTEM_ADMIN, _msgSender());
+        _setupRole(Roles.BOND_ADMIN, _msgSender());
     }
 
     /**
@@ -54,7 +67,7 @@ contract BondMediator is OwnableUpgradeable, UUPSUpgradeable {
         uint256 expiryTimestamp,
         uint256 minimumDeposit,
         string calldata data
-    ) external onlyOwner returns (address) {
+    ) external onlyRole(Roles.BOND_ADMIN) returns (address) {
         address bond = _creator.createBond(
             name,
             symbol,
@@ -88,6 +101,6 @@ contract BondMediator is OwnableUpgradeable, UUPSUpgradeable {
     function _authorizeUpgrade(address newImplementation)
         internal
         override
-        onlyOwner
+        onlyRole(Roles.SYSTEM_ADMIN)
     {}
 }

--- a/contracts/bond/BondMediator.sol
+++ b/contracts/bond/BondMediator.sol
@@ -48,6 +48,7 @@ contract BondMediator is AccessControlUpgradeable, UUPSUpgradeable {
         _creator = BondCreator(factory);
         _curator = BondCurator(manager);
 
+        _setRoleAdmin(Roles.BOND_ADMIN, Roles.DAO_ADMIN);
         _setRoleAdmin(Roles.SYSTEM_ADMIN, Roles.DAO_ADMIN);
         _setupRole(Roles.DAO_ADMIN, _msgSender());
         _setupRole(Roles.SYSTEM_ADMIN, _msgSender());

--- a/contracts/bond/Roles.sol
+++ b/contracts/bond/Roles.sol
@@ -1,0 +1,16 @@
+// SPDX-License-Identifier: Apache-2.0
+pragma solidity ^0.8.0;
+
+/**
+ * @title Roles within the Bond access control schema.
+ *
+ * @notice The DAO grants all other roles (role admin for all roles), while not permitted any actions itself.
+ *
+ *  SYSTEM_ADMIN role deals with upgrading the contract.
+ *  BOND_ADMIN role is deals with the Bond life cycle.
+ */
+library Roles {
+    bytes32 public constant DAO_ADMIN = "DAO_ADMIN";
+    bytes32 public constant BOND_ADMIN = "BOND_ADMIN";
+    bytes32 public constant SYSTEM_ADMIN = "SYSTEM_ADMIN";
+}

--- a/contracts/bond/Roles.sol
+++ b/contracts/bond/Roles.sol
@@ -6,11 +6,13 @@ pragma solidity ^0.8.0;
  *
  * @notice The DAO grants all other roles (role admin for all roles), while not permitted any actions itself.
  *
- *  SYSTEM_ADMIN role deals with upgrading the contract.
  *  BOND_ADMIN role is deals with the Bond life cycle.
+ *  BOND_AGGREGATOR roles collates bonds together in one place.
+ *  SYSTEM_ADMIN role deals with upgrading the contract.
  */
 library Roles {
     bytes32 public constant DAO_ADMIN = "DAO_ADMIN";
     bytes32 public constant BOND_ADMIN = "BOND_ADMIN";
+    bytes32 public constant BOND_AGGREGATOR = "BOND_AGGREGATOR";
     bytes32 public constant SYSTEM_ADMIN = "SYSTEM_ADMIN";
 }

--- a/scripts/bond/create-bond.ts
+++ b/scripts/bond/create-bond.ts
@@ -1,6 +1,6 @@
 import {ethers, run} from 'hardhat'
-import {BondMediator} from '../typechain'
-import {log} from '../config/logging'
+import {BondMediator} from '../../typechain'
+import {log} from '../../config/logging'
 import {ContractReceipt, Event} from 'ethers'
 
 const BOND_MEDIATOR_ADDRESS = '0x5023cC786D6596C405a98a956384012117d11118'

--- a/scripts/bond/deploy.ts
+++ b/scripts/bond/deploy.ts
@@ -1,6 +1,6 @@
 import {ethers, run} from 'hardhat'
-import {log} from '../config/logging'
-import {BitDAO, BondFactory, BondManager, BondMediator} from '../typechain'
+import {log} from '../../config/logging'
+import {BitDAO, BondFactory, BondManager, BondMediator} from '../../typechain'
 import {SignerWithAddress} from '@nomiclabs/hardhat-ethers/signers'
 
 async function main() {

--- a/test/bond-factory.test.ts
+++ b/test/bond-factory.test.ts
@@ -77,7 +77,7 @@ describe('BondFactory contract', () => {
                     name: bondName,
                     debtSymbol: bondSymbol,
                     debtAmount: debtTokenAmount,
-                    owner: admin,
+                    creator: admin,
                     treasury: treasury,
                     expiryTimestamp: expiryTimestamp,
                     data: data
@@ -128,12 +128,14 @@ describe('BondFactory contract', () => {
                 )
             })
 
-            it('only owner', async () => {
+            it('only bond admin', async () => {
                 await expect(
                     bonds
                         .connect(nonAdmin)
                         .whitelistCollateral(collateralTokens.address)
-                ).to.be.revertedWith('Ownable: caller is not the owner')
+                ).to.be.revertedWith(
+                    'AccessControl: account 0x3c44cdddb6a900fa2b585dd299e03d12fa4293bc is missing role 0x424f4e445f41444d494e00000000000000000000000000000000000000000000'
+                )
             })
         })
 
@@ -166,12 +168,14 @@ describe('BondFactory contract', () => {
                 )
             })
 
-            it('only owner', async () => {
+            it('only bond admin', async () => {
                 await expect(
                     bonds
                         .connect(nonAdmin)
                         .updateWhitelistedCollateral(collateralTokens.address)
-                ).to.be.revertedWith('Ownable: caller is not the owner')
+                ).to.be.revertedWith(
+                    'AccessControl: account 0x3c44cdddb6a900fa2b585dd299e03d12fa4293bc is missing role 0x424f4e445f41444d494e00000000000000000000000000000000000000000000'
+                )
             })
 
             it('existing address', async () => {
@@ -219,12 +223,14 @@ describe('BondFactory contract', () => {
                 ).to.be.revertedWith('Whitelist: not whitelisted')
             })
 
-            it('only owner', async () => {
+            it('only bond admin', async () => {
                 await expect(
                     bonds
                         .connect(nonAdmin)
                         .removeWhitelistedCollateral(collateralSymbol)
-                ).to.be.revertedWith('Ownable: caller is not the owner')
+                ).to.be.revertedWith(
+                    'AccessControl: account 0x3c44cdddb6a900fa2b585dd299e03d12fa4293bc is missing role 0x424f4e445f41444d494e00000000000000000000000000000000000000000000'
+                )
             })
         })
     })
@@ -267,10 +273,12 @@ describe('BondFactory contract', () => {
                 ).to.be.revertedWith('BF: treasury is zero address')
             })
 
-            it('only owner', async () => {
+            it('only bond admin', async () => {
                 await expect(
                     bonds.connect(nonAdmin).setTreasury(treasury)
-                ).to.be.revertedWith('Ownable: caller is not the owner')
+                ).to.be.revertedWith(
+                    'AccessControl: account 0x3c44cdddb6a900fa2b585dd299e03d12fa4293bc is missing role 0x424f4e445f41444d494e00000000000000000000000000000000000000000000'
+                )
             })
         })
     })

--- a/test/contracts/bond/bond-factory-events.ts
+++ b/test/contracts/bond/bond-factory-events.ts
@@ -10,7 +10,7 @@ export function createBondEvent(event: Event): {
     name: string
     debtSymbol: string
     debtAmount: BigNumber
-    owner: string
+    creator: string
     treasury: string
     expiryTimestamp: BigNumber
     data: string
@@ -23,7 +23,7 @@ export function createBondEvent(event: Event): {
     expect(args?.name).is.not.undefined
     expect(args?.debtSymbol).is.not.undefined
     expect(args?.debtAmount).is.not.undefined
-    expect(args?.owner).is.not.undefined
+    expect(args?.creator).is.not.undefined
     expect(args?.treasury).is.not.undefined
     expect(args?.expiryTimestamp).is.not.undefined
     expect(args?.data).is.not.undefined

--- a/test/contracts/bond/verify-bond-factory-events.ts
+++ b/test/contracts/bond/verify-bond-factory-events.ts
@@ -12,7 +12,7 @@ export async function verifyCreateBondEvent(
         name: string
         debtSymbol: string
         debtAmount: bigint
-        owner: string
+        creator: string
         treasury: string
         expiryTimestamp: bigint
         data: string
@@ -21,14 +21,14 @@ export async function verifyCreateBondEvent(
 ): Promise<void> {
     const creationEvent = createBondEvent(event('CreateBond', receipt))
     expect(ethers.utils.isAddress(creationEvent.bond)).is.true
-    expect(creationEvent.bond).is.not.equal(expected.owner)
+    expect(creationEvent.bond).is.not.equal(expected.creator)
     expect(creationEvent.bond).is.not.equal(expected.treasury)
     expect(await ethers.provider.getCode(creationEvent.bond)).is.not.undefined
     expect(creationEvent.name).equals(expected.name)
     expect(creationEvent.debtSymbol).equals(expected.debtSymbol)
     expect(creationEvent.debtAmount).equals(expected.debtAmount)
     expect(creationEvent.expiryTimestamp).equals(expected.expiryTimestamp)
-    expect(creationEvent.owner).equals(expected.owner)
+    expect(creationEvent.creator).equals(expected.creator)
     expect(creationEvent.treasury).equals(expected.treasury)
     expect(creationEvent.data).equals(expected.data)
 }


### PR DESCRIPTION
### Purpose for this PR
Splits admins into four types:
1. DAO: role for all other admin roles
2. SysAdmin: allowed to upgrade contracts
3. Bond Aggregator: allowed to add bonds to the manager
4. Bond: ever previous Owner function.

<!-- Have you included adequate testing for this change? -->
Closes https://github.com/windranger-io/windranger-treasury/issues/162