### PR TITLE
fix: scripting change support for windows

### DIFF
--- a/package.json
+++ b/package.json
@@ -17,14 +17,14 @@
     "build": "hardhat compile",
     "clean": "hardhat clean",
     "format": "npm run format-sol && npm run format-ts",
-    "format-sol": "prettier '**/*.sol' --write",
-    "format-ts": "prettier '**/*.ts' --write",
+    "format-sol": "prettier **/*.sol --write",
+    "format-ts": "prettier **/*.ts --write",
     "lint": "npm run lint-ts && npm run lint-sol",
     "lint-ts": "eslint . --ext .ts",
     "lint-sol": "solhint 'contracts/**/*.sol'",
     "plant": "npx node-plantuml ./docs/specs",
     "prepare": "husky install",
-    "test": "mocha --timeout 10000 --exit --recursive --require ts-node/register 'test/**/*.test.ts'"
+    "test": "mocha --timeout 10000 --exit --recursive --require ts-node/register test/**/*.test.ts"
   },
   "devDependencies": {
     "@nomiclabs/hardhat-ethers": "^2.0.3",


### PR DESCRIPTION
### Purpose for this PR
The single quotes break the script on both Powershell and Terminal, changing to remove the single quotes has them working across Windows and MacOs (zsh)
<!-- Have you included adequate testing for this change? -->
