### PR TITLE
feat: partial release

### DIFF
--- a/test/contracts/bond/single-collateral-bond-events.ts
+++ b/test/contracts/bond/single-collateral-bond-events.ts
@@ -6,6 +6,8 @@ import {
     ExpireEvent,
     FullCollateralEvent,
     PartialCollateralEvent,
+    PartialReleaseEvent,
+    PartialReleaseWithdrawEvent,
     RedemptionEvent,
     SlashEvent,
     WithdrawCollateralEvent
@@ -215,4 +217,42 @@ export function withdrawCollateralEvent(event: Event): {
     expect(args?.collateralAmount).is.not.undefined
 
     return withdraw.args
+}
+
+/**
+ * Shape check and conversion for a PartialReleaseEvent.
+ */
+export function partialReleaseEvent(event: Event): {
+    collateralSymbol: string
+    collateralAmount: BigNumber
+} {
+    const partialRelease = event as PartialReleaseEvent
+    expect(partialRelease.args).is.not.undefined
+
+    const args = partialRelease.args
+    expect(args?.collateralSymbol).is.not.undefined
+    expect(args?.collateralAmount).is.not.undefined
+
+    return partialRelease.args
+}
+
+/**
+ * Shape check and conversion for a PartialReleaseWithdraw.
+ */
+export function partialReleaseWithdrawEvent(event: Event): {
+    user: string
+    debtSymbol: string
+    collateralSymbol: string
+    partialReleaseAmount: BigNumber
+} {
+    const debt = event as PartialReleaseWithdrawEvent
+    expect(debt.args).is.not.undefined
+
+    const args = debt.args
+    expect(args?.user).is.not.undefined
+    expect(args?.debtSymbol).is.not.undefined
+    expect(args?.collateralSymbol).is.not.undefined
+    expect(args?.partialReleaseAmount).is.not.undefined
+
+    return debt.args
 }

--- a/test/contracts/bond/verify-single-collateral-bond-events.ts
+++ b/test/contracts/bond/verify-single-collateral-bond-events.ts
@@ -13,7 +13,9 @@ import {
     redemptionEvent,
     slashEvent,
     transferEvents,
-    withdrawCollateralEvent
+    withdrawCollateralEvent,
+    partialReleaseEvent,
+    partialReleaseWithdrawEvent
 } from './single-collateral-bond-events'
 import {verifyOrderedEvents} from '../../framework/verify'
 
@@ -203,4 +205,54 @@ function deepEqualsTokenTransfer(
         actual.from === expected.from &&
         actual.value.toBigInt() === expected.amount
     )
+}
+
+/**
+ * Verifies the content for a PartialRelease event.
+ */
+export function verifyPartialReleaseEvent(
+    receipt: ContractReceipt,
+    collateral: ExpectTokenBalance
+): void {
+    const onlyPartialReleaseEvent = partialReleaseEvent(
+        event('PartialRelease', receipt)
+    )
+    expect(
+        onlyPartialReleaseEvent.collateralSymbol,
+        'PartialRelease symbol'
+    ).equals(collateral.symbol)
+    expect(
+        onlyPartialReleaseEvent.collateralAmount,
+        'PartialRelease amount'
+    ).equals(collateral.amount)
+}
+
+/**
+ * Verifies the content for a PartialReleaseWithdraw event.
+ */
+export function verifyPartialReleaseWithdrawEvent(
+    receipt: ContractReceipt,
+    user: string,
+    debt: ExpectTokenBalance,
+    collateral: ExpectTokenBalance
+): void {
+    const onlyPartialReleaseWithdrawEvent = partialReleaseWithdrawEvent(
+        event('PartialReleaseWithdraw', receipt)
+    )
+    expect(
+        onlyPartialReleaseWithdrawEvent.user,
+        'PartialReleaseWithdraw user'
+    ).equals(user)
+    expect(
+        onlyPartialReleaseWithdrawEvent.debtSymbol,
+        'PartialReleaseWithdraw debt symbol'
+    ).equals(debt.symbol)
+    expect(
+        onlyPartialReleaseWithdrawEvent.collateralSymbol,
+        'PartialReleaseWithdraw collateral symbol'
+    ).equals(collateral.symbol)
+    expect(
+        onlyPartialReleaseWithdrawEvent.partialReleaseAmount,
+        'PartialReleaseWithdraw collateral amount'
+    ).equals(collateral.amount)
 }


### PR DESCRIPTION
### Purpose for this PR

GH issue 60 - partial release, implementing the logic below, with unit tests in the test files.

In a simple scenario where this is only ONE user purchasing the bonds with BIT:

    User sends 100 BIT, the contract takes it and issues him 100 BOND (the ERC20 token of this contract);
    Users sends 100, 100, 100, 100 BIT in a row, now the collateral is 500 BIT, user get 500 BOND;
    Now we slash 50 BIT;
    We partial release 75 BIT back to the pool;
    We slash 50 BIT again;
    We release 75 BIT again;
    Now we open the redemption;

Using the 500 BOND the user still holds, he can redeem 500 - (50+75+50+75) = 250 BIT

The user can withdraw 75 + 75 = 150 BIT due to the "partial release" back to the pool.

Is the above computation what we want?

If yes the a simple solution seems to be:

    Create a total_deposit variable to track the total_deposit
    Use a map to track each user's bond payment;
    Keep a running _collateral that will be reduced each time a "slash" AND "partial release" happens;
    Keep a running _partial_release_total that increment with each partial release;
    Create a withdraw function for withdrawing partial release, withdrawal_amount = user_total_deposit * partial_release_total / total_deposit

The above solution depends on allowing withdrawal after allowing redemption, so all the slashes and partial releases are already done by the admin, which seems logical to me, so user can withdraw the partial release at one shot.




