### PR TITLE
fix: typing anonymous parameters

### DIFF
--- a/test/contracts/bond/bond-creator-events.ts
+++ b/test/contracts/bond/bond-creator-events.ts
@@ -2,10 +2,7 @@ import {BigNumber, Event} from 'ethers'
 import {CreateBondEvent} from '../../../typechain-types/BondFactory'
 import {expect} from 'chai'
 
-/**
- * Shape check and conversion for a CreateBondEvent.
- */
-export function createBondEvent(event: Event): {
+export type ActualCreateBondEvent = {
     bond: string
     name: string
     debtSymbol: string
@@ -14,7 +11,12 @@ export function createBondEvent(event: Event): {
     treasury: string
     expiryTimestamp: BigNumber
     data: string
-} {
+}
+
+/**
+ * Shape check and conversion for a CreateBondEvent.
+ */
+export function createBondEvent(event: Event): ActualCreateBondEvent {
     const create = event as CreateBondEvent
     expect(event.args).is.not.undefined
 

--- a/test/contracts/bond/bond-curator-events.ts
+++ b/test/contracts/bond/bond-curator-events.ts
@@ -3,15 +3,15 @@ import {expect} from 'chai'
 import {AddBondEvent} from '../../../typechain-types/BondManager'
 import {Result} from '@ethersproject/abi'
 
-export type AddBond = {
+export type ActualAddBondEvent = {
     bond: string
 }
 
 /**
  * Shape check and conversion for a AddBondEvent.
  */
-export function addBondEvents(events: Event[]): AddBond[] {
-    const bonds: AddBond[] = []
+export function addBondEvents(events: Event[]): ActualAddBondEvent[] {
+    const bonds: ActualAddBondEvent[] = []
 
     for (const event of events) {
         const create = event as AddBondEvent
@@ -29,8 +29,8 @@ export function addBondEvents(events: Event[]): AddBond[] {
 /**
  * Shape check and conversion for a event log entry for AddBond.
  */
-export function addBondEventLogs(events: Result[]): AddBond[] {
-    const results: AddBond[] = []
+export function addBondEventLogs(events: Result[]): ActualAddBondEvent[] {
+    const results: ActualAddBondEvent[] = []
 
     for (const event of events) {
         expect(event?.bond).is.not.undefined

--- a/test/contracts/bond/single-collateral-bond-events.ts
+++ b/test/contracts/bond/single-collateral-bond-events.ts
@@ -12,36 +12,62 @@ import {
 } from '../../../typechain-types/ERC20SingleCollateralBond'
 import {TransferEvent} from '../../../typechain-types/IERC20'
 
-/**
- * Expected balance combination of a symbol and amount (value).
- */
-export type ExpectTokenBalance = {
-    symbol: string
-    amount: bigint
+export type ActualAllowRedemptionEvent = {authorizer: string}
+
+export type ActualDebtIssueEvent = {
+    receiver: string
+    debSymbol: string
+    debtAmount: BigNumber
 }
 
-/**
- * Expected ERC20 token transfer event.
- */
-export type ExpectTokenTransfer = {
+export type ActualExpireEvent = {
+    sender: string
+    treasury: string
+    collateralSymbol: string
+    collateralAmount: BigNumber
+}
+
+export type ActualFullCollateralEvent = {
+    collateralSymbol: string
+    collateralAmount: BigNumber
+}
+
+export type ActualPartialCollateralEvent = {
+    collateralSymbol: string
+    collateralAmount: BigNumber
+    debtSymbol: string
+    debtRemaining: BigNumber
+}
+
+export type ActualRedemptionEvent = {
+    redeemer: string
+    debtSymbol: string
+    debtAmount: BigNumber
+    collateralSymbol: string
+    collateralAmount: BigNumber
+}
+
+export type ActualSlashEvent = {
+    collateralSymbol: string
+    collateralAmount: BigNumber
+}
+
+export type ActualTransferEvents = {
     from: string
     to: string
-    amount: bigint
+    value: BigNumber
 }
 
-/**
- * Expected transfer event, withdrawing the remaining token amount from a Bond.
- */
-export type ExpectFlushTransfer = {
-    to: string
-    symbol: string
-    amount: bigint
+export type ActualWithdrawCollateralEvent = {
+    treasury: string
+    collateralSymbol: string
+    collateralAmount: BigNumber
 }
 
 /**
  * Shape check and conversion for a AllowRedemptionEvent.
  */
-export function allowRedemptionEvent(event: Event): {authorizer: string} {
+export function allowRedemptionEvent(event: Event): ActualAllowRedemptionEvent {
     const redemption = event as AllowRedemptionEvent
     expect(redemption.args).is.not.undefined
 
@@ -54,11 +80,7 @@ export function allowRedemptionEvent(event: Event): {authorizer: string} {
 /**
  * Shape check and conversion for a DebtIssueEvent.
  */
-export function debtIssueEvent(event: Event): {
-    receiver: string
-    debSymbol: string
-    debtAmount: BigNumber
-} {
+export function debtIssueEvent(event: Event): ActualDebtIssueEvent {
     const debt = event as DebtIssueEvent
     expect(debt.args).is.not.undefined
 
@@ -73,12 +95,7 @@ export function debtIssueEvent(event: Event): {
 /**
  * Shape check and conversion for a ExpireEvent.
  */
-export function expireEvent(event: Event): {
-    sender: string
-    treasury: string
-    collateralSymbol: string
-    collateralAmount: BigNumber
-} {
+export function expireEvent(event: Event): ActualExpireEvent {
     const expire = event as ExpireEvent
     expect(expire.args).is.not.undefined
 
@@ -94,10 +111,7 @@ export function expireEvent(event: Event): {
 /**
  * Shape check and conversion for a FullCollateralEvent.
  */
-export function fullCollateralEvent(event: Event): {
-    collateralSymbol: string
-    collateralAmount: BigNumber
-} {
+export function fullCollateralEvent(event: Event): ActualFullCollateralEvent {
     const collateral = event as FullCollateralEvent
     expect(collateral.args).is.not.undefined
 
@@ -111,12 +125,9 @@ export function fullCollateralEvent(event: Event): {
 /**
  * Shape check and conversion for a PartialCollateralEvent.
  */
-export function partialCollateralEvent(event: Event): {
-    collateralSymbol: string
-    collateralAmount: BigNumber
-    debtSymbol: string
-    debtRemaining: BigNumber
-} {
+export function partialCollateralEvent(
+    event: Event
+): ActualPartialCollateralEvent {
     const collateral = event as PartialCollateralEvent
     expect(collateral.args).is.not.undefined
 
@@ -132,13 +143,7 @@ export function partialCollateralEvent(event: Event): {
 /**
  * Shape check and conversion for a RedemptionEvent.
  */
-export function redemptionEvent(event: Event): {
-    redeemer: string
-    debtSymbol: string
-    debtAmount: BigNumber
-    collateralSymbol: string
-    collateralAmount: BigNumber
-} {
+export function redemptionEvent(event: Event): ActualRedemptionEvent {
     const debt = event as RedemptionEvent
     expect(debt.args).is.not.undefined
 
@@ -155,10 +160,7 @@ export function redemptionEvent(event: Event): {
 /**
  * Shape check and conversion for a SlashEvent.
  */
-export function slashEvent(event: Event): {
-    collateralSymbol: string
-    collateralAmount: BigNumber
-} {
+export function slashEvent(event: Event): ActualSlashEvent {
     const slash = event as SlashEvent
     expect(slash.args).is.not.undefined
 
@@ -172,11 +174,7 @@ export function slashEvent(event: Event): {
 /**
  * Shape check and conversion for a TransferEvents.
  */
-export function transferEvents(events: Event[]): {
-    from: string
-    to: string
-    value: BigNumber
-}[] {
+export function transferEvents(events: Event[]): ActualTransferEvents[] {
     const converted: {
         from: string
         to: string
@@ -201,11 +199,9 @@ export function transferEvents(events: Event[]): {
 /**
  * Shape check and conversion for a WithdrawCollateralEvent.
  */
-export function withdrawCollateralEvent(event: Event): {
-    treasury: string
-    collateralSymbol: string
-    collateralAmount: BigNumber
-} {
+export function withdrawCollateralEvent(
+    event: Event
+): ActualWithdrawCollateralEvent {
     const withdraw = event as WithdrawCollateralEvent
     expect(withdraw.args).is.not.undefined
 

--- a/test/contracts/bond/verify-bond-creator-events.ts
+++ b/test/contracts/bond/verify-bond-creator-events.ts
@@ -4,19 +4,21 @@ import {expect} from 'chai'
 import {ethers} from 'hardhat'
 import {ContractReceipt} from 'ethers'
 
+export type ActualVerifyCreateBondEvent = {
+    name: string
+    debtSymbol: string
+    debtAmount: bigint
+    creator: string
+    treasury: string
+    expiryTimestamp: bigint
+    data: string
+}
+
 /**
  * Verifies the content for a Create Bond event.
  */
 export async function verifyCreateBondEvent(
-    expected: {
-        name: string
-        debtSymbol: string
-        debtAmount: bigint
-        creator: string
-        treasury: string
-        expiryTimestamp: bigint
-        data: string
-    },
+    expected: ActualVerifyCreateBondEvent,
     receipt: ContractReceipt
 ): Promise<void> {
     const creationEvent = createBondEvent(event('CreateBond', receipt))

--- a/test/contracts/bond/verify-curator-events.ts
+++ b/test/contracts/bond/verify-curator-events.ts
@@ -1,5 +1,9 @@
 import {BaseContract, ContractReceipt} from 'ethers'
-import {AddBond, addBondEventLogs, addBondEvents} from './bond-curator-events'
+import {
+    ActualAddBondEvent,
+    addBondEventLogs,
+    addBondEvents
+} from './bond-curator-events'
 import {eventLog} from '../../framework/event-logs'
 import {verifyOrderedEvents} from '../../framework/verify'
 import {events} from '../../framework/events'
@@ -18,7 +22,7 @@ export function verifyAddBondEvents(
     verifyOrderedEvents(
         actualEvents,
         bonds,
-        (actual: AddBond, expected: ExpectedAddBondEvent) =>
+        (actual: ActualAddBondEvent, expected: ExpectedAddBondEvent) =>
             deepEqualsAddBondEvent(actual, expected)
     )
 }
@@ -36,13 +40,13 @@ export function verifyAddBondLogEvents<T extends BaseContract>(
     verifyOrderedEvents(
         actualEvents,
         bonds,
-        (actual: AddBond, expected: ExpectedAddBondEvent) =>
+        (actual: ActualAddBondEvent, expected: ExpectedAddBondEvent) =>
             deepEqualsAddBondEvent(actual, expected)
     )
 }
 
 function deepEqualsAddBondEvent(
-    actual: AddBond,
+    actual: ActualAddBondEvent,
     expected: ExpectedAddBondEvent
 ): boolean {
     return actual.bond === expected.bond

--- a/test/contracts/bond/verify-single-collateral-bond-events.ts
+++ b/test/contracts/bond/verify-single-collateral-bond-events.ts
@@ -2,9 +2,6 @@ import {BigNumber, ContractReceipt} from 'ethers'
 import {event, events} from '../../framework/events'
 import {expect} from 'chai'
 import {
-    ExpectFlushTransfer,
-    ExpectTokenBalance,
-    ExpectTokenTransfer,
     allowRedemptionEvent,
     debtIssueEvent,
     expireEvent,
@@ -16,6 +13,32 @@ import {
     withdrawCollateralEvent
 } from './single-collateral-bond-events'
 import {verifyOrderedEvents} from '../../framework/verify'
+
+/**
+ * Expected balance combination of a symbol and amount (value).
+ */
+export type ExpectTokenBalance = {
+    symbol: string
+    amount: bigint
+}
+
+/**
+ * Expected ERC20 token transfer event.
+ */
+export type ExpectTokenTransfer = {
+    from: string
+    to: string
+    amount: bigint
+}
+
+/**
+ * Expected transfer event, withdrawing the remaining token amount from a Bond.
+ */
+export type ExpectFlushTransfer = {
+    to: string
+    symbol: string
+    amount: bigint
+}
 
 type ActualTokenTransfer = {
     from: string

--- a/test/contracts/bond/verify-single-collateral-bond-events.ts
+++ b/test/contracts/bond/verify-single-collateral-bond-events.ts
@@ -22,28 +22,26 @@ export type ExpectTokenBalance = {
     amount: bigint
 }
 
-/**
- * Expected ERC20 token transfer event.
- */
-export type ExpectTokenTransfer = {
+export type ExpectTokenTransferEvent = {
     from: string
     to: string
     amount: bigint
 }
 
-/**
- * Expected transfer event, withdrawing the remaining token amount from a Bond.
- */
-export type ExpectFlushTransfer = {
+export type ExpectFlushTransferEvent = {
     to: string
     symbol: string
     amount: bigint
 }
 
-type ActualTokenTransfer = {
+export type ActualTokenTransferEvent = {
     from: string
     to: string
     value: BigNumber
+}
+
+export type ExpectAllowRedemptionEvent = {
+    authorizer: string
 }
 
 /**
@@ -51,13 +49,13 @@ type ActualTokenTransfer = {
  */
 export function verifyAllowRedemptionEvent(
     receipt: ContractReceipt,
-    authorizer: string
+    expected: ExpectAllowRedemptionEvent
 ): void {
     const allowRedemption = allowRedemptionEvent(
         event('AllowRedemption', receipt)
     )
     expect(allowRedemption.authorizer, 'AllowRedemption authorizer').equals(
-        authorizer
+        expected.authorizer
     )
 }
 
@@ -186,15 +184,17 @@ export function verifySlashEvent(
  */
 export function verifyTransferEvents(
     receipt: ContractReceipt,
-    expectedTransfers: ExpectTokenTransfer[]
+    expectedTransfers: ExpectTokenTransferEvent[]
 ): void {
     const actualTransfers = transferEvents(events('Transfer', receipt))
 
     verifyOrderedEvents(
         actualTransfers,
         expectedTransfers,
-        (actual: ActualTokenTransfer, expected: ExpectTokenTransfer) =>
-            deepEqualsTokenTransfer(actual, expected)
+        (
+            actual: ActualTokenTransferEvent,
+            expected: ExpectTokenTransferEvent
+        ) => deepEqualsTokenTransfer(actual, expected)
     )
 }
 
@@ -203,7 +203,7 @@ export function verifyTransferEvents(
  */
 export function verifyWithdrawCollateralEvent(
     receipt: ContractReceipt,
-    transfer: ExpectFlushTransfer
+    transfer: ExpectFlushTransferEvent
 ): void {
     const onlyTransferEvent = withdrawCollateralEvent(
         event('WithdrawCollateral', receipt)
@@ -218,8 +218,8 @@ export function verifyWithdrawCollateralEvent(
 }
 
 function deepEqualsTokenTransfer(
-    actual: ActualTokenTransfer,
-    expected: ExpectTokenTransfer
+    actual: ActualTokenTransferEvent,
+    expected: ExpectTokenTransferEvent
 ): boolean {
     return (
         actual.to === expected.to &&

--- a/test/erc20-single-collateral-bond.test.ts
+++ b/test/erc20-single-collateral-bond.test.ts
@@ -878,7 +878,9 @@ describe('ERC20 Single Collateral Bond contract', () => {
 
         // Bond redemption allowed by Owner
         const allowRedemptionReceipt = await allowRedemption()
-        verifyAllowRedemptionEvent(allowRedemptionReceipt, admin.address)
+        verifyAllowRedemptionEvent(allowRedemptionReceipt, {
+            authorizer: admin.address
+        })
 
         // Guarantor One redeem their bond, partial conversion (slashed)
         const redeemOneReceipt = await redeem(guarantorOne, pledge)
@@ -979,7 +981,9 @@ describe('ERC20 Single Collateral Bond contract', () => {
 
         // Bond redemption allowed by Owner
         const allowRedemptionReceipt = await allowRedemption()
-        verifyAllowRedemptionEvent(allowRedemptionReceipt, admin.address)
+        verifyAllowRedemptionEvent(allowRedemptionReceipt, {
+            authorizer: admin.address
+        })
         verifyPartialCollateralEvent(
             allowRedemptionReceipt,
             {
@@ -1101,7 +1105,9 @@ describe('ERC20 Single Collateral Bond contract', () => {
 
         // Bond redemption allowed by Owner
         const allowRedemptionReceipt = await allowRedemption()
-        verifyAllowRedemptionEvent(allowRedemptionReceipt, admin.address)
+        verifyAllowRedemptionEvent(allowRedemptionReceipt, {
+            authorizer: admin.address
+        })
 
         // Guarantor One redeem their bond, full conversion
         const redeemOneReceipt = await redeem(guarantorOne, pledgeOne)
@@ -1279,7 +1285,9 @@ describe('ERC20 Single Collateral Bond contract', () => {
 
         // Bond redemption allowed by Owner
         const allowRedemptionReceipt = await allowRedemption()
-        verifyAllowRedemptionEvent(allowRedemptionReceipt, admin.address)
+        verifyAllowRedemptionEvent(allowRedemptionReceipt, {
+            authorizer: admin.address
+        })
         verifyPartialCollateralEvent(
             allowRedemptionReceipt,
             {symbol: collateralSymbol, amount: pledgeOne + pledgeTwo},
@@ -1575,7 +1583,9 @@ describe('ERC20 Single Collateral Bond contract', () => {
 
         // Bond redemption allowed by Owner
         const allowRedemptionReceipt = await allowRedemption()
-        verifyAllowRedemptionEvent(allowRedemptionReceipt, admin.address)
+        verifyAllowRedemptionEvent(allowRedemptionReceipt, {
+            authorizer: admin.address
+        })
 
         // Guarantor One redeem their bond, partial conversion (slashed)
         const redeemOneReceipt = await redeem(guarantorOne, pledgeOne)


### PR DESCRIPTION
### Purpose for this PR
Mixed example are only going to cause confusion, converting all over to using typed parameter and return objects instead of anonymous types.

Motivation for explicitly typing is easier to read signatures and it better leverages TS (generally lower maintenance)
<!-- Have you included adequate testing for this change? -->
