### PR TITLE
feat: treasury from factory to mediator

### DIFF
--- a/contracts/bond/BondCreator.sol
+++ b/contracts/bond/BondCreator.sol
@@ -1,6 +1,9 @@
 // SPDX-License-Identifier: Apache-2.0
 pragma solidity ^0.8.0;
 
+import "./BondIdentity.sol";
+import "./BondSettings.sol";
+
 /**
  * @title Deploys new Bonds.
  *
@@ -22,23 +25,10 @@ interface BondCreator {
     /**
      * @notice Deploys and initialises a new Bond.
      *
-     * @param name Description of the purpose of the Bond.
-     * @param symbol Abbreviation to identify the Bond.
-     * @param debtTokens Number of tokens to create, which get swapped for collateral tokens by depositing.
-     * @param collateralTokenSymbol Abbreviation of the collateral token that are swapped for debt tokens in deposit.
-     * @param expiryTimestamp Unix timestamp for when the Bond is expired and anyone can move the remaining collateral
-     *              to the Treasury, then petition for redemption.
-     * @param minimumDeposit Minimum debt holding allowed in the deposit phase. Once the minimum is met,
-     *              any sized deposit from that account is allowed, as the minimum has already been met.
-     * @param data Metadata not required for the operation of the Bond, but needed by external actors.
+     * @param id Identity for the Bond to create.
+     * @param config Values to use during the Bond creation process.
      */
-    function createBond(
-        string calldata name,
-        string calldata symbol,
-        uint256 debtTokens,
-        string calldata collateralTokenSymbol,
-        uint256 expiryTimestamp,
-        uint256 minimumDeposit,
-        string calldata data
-    ) external returns (address);
+    function createBond(BondIdentity calldata id, BondSettings calldata config)
+        external
+        returns (address);
 }

--- a/contracts/bond/BondIdentity.sol
+++ b/contracts/bond/BondIdentity.sol
@@ -1,0 +1,12 @@
+// SPDX-License-Identifier: Apache-2.0
+pragma solidity ^0.8.0;
+
+/**
+ * @@title The identity of a Bond.
+ */
+struct BondIdentity {
+    /** Description of the purpose of the Bond. */
+    string name;
+    /** Abbreviation to identify the Bond. */
+    string symbol;
+}

--- a/contracts/bond/BondMediator.sol
+++ b/contracts/bond/BondMediator.sol
@@ -8,6 +8,8 @@ import "@openzeppelin/contracts-upgradeable/security/PausableUpgradeable.sol";
 import "./BondAccessControl.sol";
 import "./BondCreator.sol";
 import "./BondCurator.sol";
+import "./BondIdentity.sol";
+import "./BondSettings.sol";
 import "./Roles.sol";
 import "../Version.sol";
 
@@ -26,18 +28,21 @@ contract BondMediator is
     BondCreator private _creator;
     BondCurator private _curator;
 
+    address private _treasury;
+
     /**
      * @notice The _msgSender() is given membership of all roles, to allow granting and future renouncing after others
      *      have been setup.
      *
      * @param factory A deployed BondCreator contract to use when creating bonds.
      * @param manager A deployed BondCurator contract to register created bonds with,
+     * @param erc20CapableTreasury Treasury that receives forfeited collateral. Must not be address zero.
      */
-    function initialize(address factory, address manager)
-        external
-        virtual
-        initializer
-    {
+    function initialize(
+        address factory,
+        address manager,
+        address erc20CapableTreasury
+    ) external virtual initializer {
         require(
             AddressUpgradeable.isContract(factory),
             "Mediator: creator not a contract"
@@ -46,10 +51,15 @@ contract BondMediator is
             AddressUpgradeable.isContract(manager),
             "Mediator: curator not a contract"
         );
+        require(
+            erc20CapableTreasury != address(0),
+            "Mediator: treasury address zero"
+        );
 
         __BondAccessControl_init();
         __UUPSUpgradeable_init();
 
+        _treasury = erc20CapableTreasury;
         _creator = BondCreator(factory);
         _curator = BondCurator(manager);
     }
@@ -68,14 +78,17 @@ contract BondMediator is
         uint256 minimumDeposit,
         string calldata data
     ) external whenNotPaused onlyRole(Roles.BOND_ADMIN) returns (address) {
+        BondIdentity memory id = BondIdentity({name: name, symbol: symbol});
         address bond = _creator.createBond(
-            name,
-            symbol,
-            debtTokens,
-            collateralTokenSymbol,
-            expiryTimestamp,
-            minimumDeposit,
-            data
+            id,
+            BondSettings({
+                debtTokens: debtTokens,
+                collateralTokenSymbol: collateralTokenSymbol,
+                treasury: _treasury,
+                expiryTimestamp: expiryTimestamp,
+                minimumDeposit: minimumDeposit,
+                data: data
+            })
         );
 
         OwnableUpgradeable(bond).transferOwnership(address(_curator));
@@ -93,6 +106,21 @@ contract BondMediator is
     }
 
     /**
+     * @notice Permits the owner to update the treasury address.
+     *
+     * @dev Only applies for bonds created after the update, previously created bond treasury addresses remain unchanged.
+     */
+    function setTreasury(address replacement)
+        external
+        whenNotPaused
+        onlyRole(Roles.BOND_ADMIN)
+    {
+        require(replacement != address(0), "Mediator: treasury address zero");
+        require(_treasury != replacement, "Mediator: same treasury address");
+        _treasury = replacement;
+    }
+
+    /**
      * @notice Resumes all paused side affecting functions.
      */
     function unpause() external whenPaused onlyRole(Roles.BOND_ADMIN) {
@@ -105,6 +133,10 @@ contract BondMediator is
 
     function bondCurator() external view returns (address) {
         return address(_curator);
+    }
+
+    function treasury() external view returns (address) {
+        return _treasury;
     }
 
     /**

--- a/contracts/bond/BondSettings.sol
+++ b/contracts/bond/BondSettings.sol
@@ -1,0 +1,26 @@
+// SPDX-License-Identifier: Apache-2.0
+pragma solidity ^0.8.0;
+
+/**
+ * @title Configuration settings for creating a new Bond.
+ */
+struct BondSettings {
+    /** Number of tokens to create, which get swapped for collateral tokens by depositing. */
+    uint256 debtTokens;
+    /** Abbreviation of the collateral token that are swapped for debt tokens in deposit. */
+    string collateralTokenSymbol;
+    /**
+     * Unix timestamp for when the Bond is expired and anyone can move the remaining collateral to the Treasury,
+     * then petitions may be made for redemption.
+     */
+    uint256 expiryTimestamp;
+    /**
+     * Minimum debt holding allowed in the deposit phase. Once the minimum is met,
+     * any sized deposit from that account is allowed, as the minimum has already been met.
+     */
+    uint256 minimumDeposit;
+    /** receiver of any slashed or swept tokens. */
+    address treasury;
+    /** Metadata not required for the operation of the Bond, but needed by external actors. */
+    string data;
+}

--- a/test/bond-factory.test.ts
+++ b/test/bond-factory.test.ts
@@ -35,8 +35,7 @@ describe('Bond Factory contract', () => {
         collateralSymbol = await collateralTokens.symbol()
         bonds = await deployContractWithProxy<BondFactory>(
             'BondFactory',
-            collateralTokens.address,
-            treasury
+            collateralTokens.address
         )
     })
 
@@ -44,13 +43,15 @@ describe('Bond Factory contract', () => {
         it('non-whitelisted collateral', async () => {
             await expect(
                 bonds.createBond(
-                    'Named bond',
-                    'AA00AA',
-                    101n,
-                    'BEEP',
-                    0n,
-                    0n,
-                    ''
+                    {name: 'Named bond', symbol: 'AA00AA'},
+                    {
+                        debtTokens: 101n,
+                        collateralTokenSymbol: 'BEEP',
+                        expiryTimestamp: 0n,
+                        minimumDeposit: 0n,
+                        treasury: treasury,
+                        data: ''
+                    }
                 )
             ).to.be.revertedWith('BF: collateral not whitelisted')
         })
@@ -66,13 +67,15 @@ describe('Bond Factory contract', () => {
 
             const receipt = await execute(
                 bonds.createBond(
-                    bondName,
-                    bondSymbol,
-                    debtTokenAmount,
-                    collateralSymbol,
-                    expiryTimestamp,
-                    minimumDeposit,
-                    data
+                    {name: bondName, symbol: bondSymbol},
+                    {
+                        debtTokens: debtTokenAmount,
+                        collateralTokenSymbol: collateralSymbol,
+                        expiryTimestamp: expiryTimestamp,
+                        minimumDeposit: minimumDeposit,
+                        treasury: treasury,
+                        data: data
+                    }
                 )
             )
 
@@ -95,13 +98,15 @@ describe('Bond Factory contract', () => {
 
             await expect(
                 bonds.createBond(
-                    'Named bond',
-                    'AA00AA',
-                    101n,
-                    'BEEP',
-                    0n,
-                    0n,
-                    ''
+                    {name: 'Named bond', symbol: 'AA00AA'},
+                    {
+                        debtTokens: 101n,
+                        collateralTokenSymbol: 'BEEP',
+                        expiryTimestamp: 0n,
+                        minimumDeposit: 0n,
+                        treasury: treasury,
+                        data: ''
+                    }
                 )
             ).to.be.revertedWith('Pausable: paused')
         })
@@ -301,65 +306,6 @@ describe('Bond Factory contract', () => {
                 await expect(
                     bonds.removeWhitelistedCollateral(symbol)
                 ).to.be.revertedWith('Pausable: paused')
-            })
-        })
-    })
-
-    describe('treasury', () => {
-        describe('retrieve', () => {
-            it(' by non-owner', async () => {
-                expect(await bonds.connect(nonAdmin).treasury()).equals(
-                    treasury
-                )
-            })
-        })
-
-        describe('update', () => {
-            before(async () => {
-                await bonds.unpause()
-            })
-            beforeEach(async () => {
-                if ((await bonds.treasury()) !== treasury) {
-                    await bonds.setTreasury(treasury)
-                }
-            })
-
-            it('to a valid address', async () => {
-                expect(await bonds.treasury()).equals(treasury)
-
-                await bonds.setTreasury(nonAdmin.address)
-
-                expect(await bonds.treasury()).equals(nonAdmin.address)
-            })
-
-            it('cannot be identical', async () => {
-                expect(await bonds.treasury()).equals(treasury)
-
-                await expect(bonds.setTreasury(treasury)).to.be.revertedWith(
-                    'BF: treasury address identical'
-                )
-            })
-
-            it('cannot be zero', async () => {
-                await expect(
-                    bonds.setTreasury(ADDRESS_ZERO)
-                ).to.be.revertedWith('BF: treasury is zero address')
-            })
-
-            it('only bond admin', async () => {
-                await expect(
-                    bonds.connect(nonAdmin).setTreasury(treasury)
-                ).to.be.revertedWith(
-                    accessControlRevertMessage(nonAdmin, BOND_ADMIN)
-                )
-            })
-
-            it('only when not paused', async () => {
-                await successfulTransaction(bonds.pause())
-                expect(await bonds.paused()).is.true
-                await expect(bonds.setTreasury(treasury)).to.be.revertedWith(
-                    'Pausable: paused'
-                )
             })
         })
     })

--- a/test/bond-manager.test.ts
+++ b/test/bond-manager.test.ts
@@ -46,8 +46,7 @@ describe('Bond Manager contract', () => {
         collateralSymbol = await collateralTokens.symbol()
         creator = await deployContractWithProxy<BondFactory>(
             'BondFactory',
-            collateralTokens.address,
-            treasury
+            collateralTokens.address
         )
     })
 
@@ -429,13 +428,15 @@ describe('Bond Manager contract', () => {
     ): Promise<ERC20SingleCollateralBond> {
         const receipt = await execute(
             creator.createBond(
-                'name',
-                'symbol',
-                100n,
-                collateralSymbol,
-                0n,
-                1n,
-                ''
+                {name: 'name', symbol: 'symbol'},
+                {
+                    debtTokens: 100n,
+                    collateralTokenSymbol: collateralSymbol,
+                    expiryTimestamp: 0n,
+                    minimumDeposit: 1n,
+                    treasury: treasury,
+                    data: ''
+                }
             )
         )
 

--- a/test/erc20-single-collateral-bond.test.ts
+++ b/test/erc20-single-collateral-bond.test.ts
@@ -66,8 +66,7 @@ describe('ERC20 Single Collateral Bond contract', () => {
         collateralSymbol = await collateralTokens.symbol()
         bonds = await deployContractWithProxy<BondFactory>(
             'BondFactory',
-            collateralTokens.address,
-            treasury
+            collateralTokens.address
         )
     })
 
@@ -409,13 +408,15 @@ describe('ERC20 Single Collateral Bond contract', () => {
         it('only after expiry', async () => {
             const receipt = await execute(
                 bonds.createBond(
-                    'Special Debt Certificate',
-                    'SDC001',
-                    500n,
-                    collateralSymbol,
-                    Date.now() + ONE_DAY_MS,
-                    MINIMUM_DEPOSIT,
-                    DATA
+                    {name: 'Special Debt Certificate', symbol: 'SDC001'},
+                    {
+                        debtTokens: 500n,
+                        collateralTokenSymbol: collateralSymbol,
+                        expiryTimestamp: Date.now() + ONE_DAY_MS,
+                        minimumDeposit: MINIMUM_DEPOSIT,
+                        treasury: treasury,
+                        data: DATA
+                    }
                 )
             )
             bond = await erc20SingleCollateralBondContractAt(
@@ -1722,13 +1723,15 @@ describe('ERC20 Single Collateral Bond contract', () => {
     ): Promise<ERC20SingleCollateralBond> {
         const receipt = await execute(
             factory.createBond(
-                'Special Debt Certificate',
-                'SDC001',
-                debtTokens,
-                collateralSymbol,
-                BOND_EXPIRY,
-                MINIMUM_DEPOSIT,
-                DATA
+                {name: 'Special Debt Certificate', symbol: 'SDC001'},
+                {
+                    debtTokens: debtTokens,
+                    collateralTokenSymbol: collateralSymbol,
+                    expiryTimestamp: BOND_EXPIRY,
+                    minimumDeposit: MINIMUM_DEPOSIT,
+                    treasury: treasury,
+                    data: DATA
+                }
             )
         )
         const creationEvent = createBondEvent(event('CreateBond', receipt))


### PR DESCRIPTION
### Purpose for this PR
Part of one of the multi-stage implementation of https://github.com/windranger-io/windranger-treasury/issues/161
<!-- Have you included adequate testing for this change? -->

Moving the `treasury` address from the `BondFactory` , which is going to be a single instance (agnostic to the DAO Id) into the `BondMediator` that will be holding all the DAO configs.