### PR TITLE
fix: moving collateral whitelist to BondMediator

### DIFF
--- a/contracts/bond/BondCreator.sol
+++ b/contracts/bond/BondCreator.sol
@@ -7,18 +7,13 @@ pragma solidity ^0.8.0;
  * @notice Creating a Bond involves the two steps of deploying and initialising.
  */
 interface BondCreator {
-    /**
-     * @@notice The identity of a Bond.
-     */
     struct BondIdentity {
         /** Description of the purpose of the Bond. */
         string name;
         /** Abbreviation to identify the Bond. */
         string symbol;
     }
-    /**
-     * @notice Configuration settings for creating a new Bond.
-     */
+
     struct BondSettings {
         /** Number of tokens to create, which get swapped for collateral tokens by depositing. */
         uint256 debtTokens;

--- a/contracts/bond/BondCreator.sol
+++ b/contracts/bond/BondCreator.sol
@@ -17,8 +17,8 @@ interface BondCreator {
     struct BondSettings {
         /** Number of tokens to create, which get swapped for collateral tokens by depositing. */
         uint256 debtTokens;
-        /** Abbreviation of the collateral token that are swapped for debt tokens in deposit. */
-        string collateralTokenSymbol;
+        /** Token contract for the collateral that is swapped for debt tokens during deposit. */
+        address collateralTokens;
         /**
          * Unix timestamp for when the Bond is expired and anyone can move the remaining collateral to the Treasury,
          * then petitions may be made for redemption.

--- a/contracts/bond/BondCreator.sol
+++ b/contracts/bond/BondCreator.sol
@@ -16,7 +16,7 @@ interface BondCreator {
 
     struct BondSettings {
         /** Number of tokens to create, which get swapped for collateral tokens by depositing. */
-        uint256 debtTokens;
+        uint256 debtTokenAmount;
         /** Token contract for the collateral that is swapped for debt tokens during deposit. */
         address collateralTokens;
         /**

--- a/contracts/bond/BondFactory.sol
+++ b/contracts/bond/BondFactory.sol
@@ -42,7 +42,7 @@ contract BondFactory is
             address(bond),
             id.name,
             id.symbol,
-            config.debtTokens,
+            config.debtTokenAmount,
             _msgSender(),
             config.treasury,
             config.expiryTimestamp,
@@ -53,7 +53,7 @@ contract BondFactory is
         bond.initialize(
             id.name,
             id.symbol,
-            config.debtTokens,
+            config.debtTokenAmount,
             config.collateralTokens,
             config.treasury,
             config.expiryTimestamp,

--- a/contracts/bond/BondMediator.sol
+++ b/contracts/bond/BondMediator.sol
@@ -93,7 +93,7 @@ contract BondMediator is
         address bond = _creator.createBond(
             id,
             BondCreator.BondSettings({
-                debtTokens: debtTokens,
+                debtTokenAmount: debtTokens,
                 collateralTokens: whitelistedCollateralAddress(
                     collateralTokenSymbol
                 ),

--- a/contracts/bond/BondMediator.sol
+++ b/contracts/bond/BondMediator.sol
@@ -8,6 +8,7 @@ import "@openzeppelin/contracts-upgradeable/security/PausableUpgradeable.sol";
 import "./BondAccessControl.sol";
 import "./BondCreator.sol";
 import "./BondCurator.sol";
+import "./CollateralWhitelist.sol";
 import "./Roles.sol";
 import "../Version.sol";
 
@@ -19,6 +20,7 @@ import "../Version.sol";
  */
 contract BondMediator is
     BondAccessControl,
+    CollateralWhitelist,
     PausableUpgradeable,
     UUPSUpgradeable,
     Version
@@ -35,31 +37,35 @@ contract BondMediator is
      * @param factory A deployed BondCreator contract to use when creating bonds.
      * @param manager A deployed BondCurator contract to register created bonds with,
      * @param erc20CapableTreasury Treasury that receives forfeited collateral. Must not be address zero.
+     * @param erc20CollateralTokens Collateral token contract. Must not be address zero.
      */
     function initialize(
         address factory,
         address manager,
-        address erc20CapableTreasury
+        address erc20CapableTreasury,
+        address erc20CollateralTokens
     ) external virtual initializer {
         require(
             AddressUpgradeable.isContract(factory),
-            "Mediator: creator not a contract"
+            "BM: creator not a contract"
         );
         require(
             AddressUpgradeable.isContract(manager),
-            "Mediator: curator not a contract"
+            "BM: curator not a contract"
         );
         require(
             erc20CapableTreasury != address(0),
-            "Mediator: treasury address zero"
+            "BM: treasury address is zero"
         );
 
         __BondAccessControl_init();
+        __CollateralWhitelist_init();
         __UUPSUpgradeable_init();
 
         _treasury = erc20CapableTreasury;
         _creator = BondCreator(factory);
         _curator = BondCurator(manager);
+        _whitelistCollateral(erc20CollateralTokens);
     }
 
     /**
@@ -76,6 +82,10 @@ contract BondMediator is
         uint256 minimumDeposit,
         string calldata data
     ) external whenNotPaused onlyRole(Roles.BOND_ADMIN) returns (address) {
+        require(
+            isCollateralWhitelisted(collateralTokenSymbol),
+            "BM: collateral not whitelisted"
+        );
         BondCreator.BondIdentity memory id = BondCreator.BondIdentity({
             name: name,
             symbol: symbol
@@ -84,7 +94,9 @@ contract BondMediator is
             id,
             BondCreator.BondSettings({
                 debtTokens: debtTokens,
-                collateralTokenSymbol: collateralTokenSymbol,
+                collateralTokens: whitelistedCollateralAddress(
+                    collateralTokenSymbol
+                ),
                 treasury: _treasury,
                 expiryTimestamp: expiryTimestamp,
                 minimumDeposit: minimumDeposit,
@@ -116,9 +128,55 @@ contract BondMediator is
         whenNotPaused
         onlyRole(Roles.BOND_ADMIN)
     {
-        require(replacement != address(0), "Mediator: treasury address zero");
-        require(_treasury != replacement, "Mediator: same treasury address");
+        require(replacement != address(0), "BM: treasury address is zero");
+        require(_treasury != replacement, "BM: identical treasury address");
         _treasury = replacement;
+    }
+
+    /**
+     * @notice Permits the owner to update the address of already whitelisted collateral token.
+     *
+     * @dev Only applies for bonds created after the update, previously created bonds remain unchanged.
+     *
+     * @param erc20CollateralTokens Must already be whitelisted and must not be address zero.
+     */
+    function updateWhitelistedCollateral(address erc20CollateralTokens)
+        external
+        whenNotPaused
+        onlyRole(Roles.BOND_ADMIN)
+    {
+        _updateWhitelistedCollateral(erc20CollateralTokens);
+    }
+
+    /**
+     * @notice Permits the owner to remove a collateral token from being accepted in future bonds.
+     *
+     * @dev Only applies for bonds created after the removal, previously created bonds remain unchanged.
+     *
+     * @param symbol Symbol must exist in the collateral whitelist.
+     */
+    function removeWhitelistedCollateral(string calldata symbol)
+        external
+        whenNotPaused
+        onlyRole(Roles.BOND_ADMIN)
+    {
+        _removeWhitelistedCollateral(symbol);
+    }
+
+    /**
+     * @notice Adds an ERC20 token to the collateral whitelist.
+     *
+     * @dev When a bond is created, the tokens used as collateral must have been whitelisted.
+     *
+     * @param erc20CollateralTokens Whitelists the token from now onwards.
+     *      On bond creation the tokens address used is retrieved by symbol from the whitelist.
+     */
+    function whitelistCollateral(address erc20CollateralTokens)
+        external
+        whenNotPaused
+        onlyRole(Roles.BOND_ADMIN)
+    {
+        _whitelistCollateral(erc20CollateralTokens);
     }
 
     /**

--- a/test/bond-factory.test.ts
+++ b/test/bond-factory.test.ts
@@ -45,7 +45,7 @@ describe('Bond Factory contract', () => {
                 bonds.createBond(
                     {name: bondName, symbol: bondSymbol},
                     {
-                        debtTokens: debtTokenAmount,
+                        debtTokenAmount: debtTokenAmount,
                         collateralTokens: collateralTokens.address,
                         expiryTimestamp: expiryTimestamp,
                         minimumDeposit: minimumDeposit,
@@ -76,7 +76,7 @@ describe('Bond Factory contract', () => {
                 bonds.createBond(
                     {name: 'Named bond', symbol: 'AA00AA'},
                     {
-                        debtTokens: 101n,
+                        debtTokenAmount: 101n,
                         collateralTokens: collateralTokens.address,
                         expiryTimestamp: 0n,
                         minimumDeposit: 0n,

--- a/test/bond-factory.test.ts
+++ b/test/bond-factory.test.ts
@@ -6,14 +6,13 @@ import '@nomiclabs/hardhat-ethers'
 import chai, {expect} from 'chai'
 import {before} from 'mocha'
 import {solidity} from 'ethereum-waffle'
-import {BitDAO, BondFactory, Box, ERC20} from '../typechain-types'
+import {BitDAO, BondFactory} from '../typechain-types'
 import {
     deployContract,
     deployContractWithProxy,
     execute,
     signer
 } from './framework/contracts'
-import {constants} from 'ethers'
 import {SignerWithAddress} from '@nomiclabs/hardhat-ethers/signers'
 import {verifyCreateBondEvent} from './contracts/bond/verify-bond-creator-events'
 import {ExtendedERC20} from './contracts/cast/extended-erc20'
@@ -24,43 +23,20 @@ import {successfulTransaction} from './framework/transaction'
 // Wires up Waffle with Chai
 chai.use(solidity)
 
-const ADDRESS_ZERO = constants.AddressZero
-
 describe('Bond Factory contract', () => {
     before(async () => {
         admin = (await signer(0)).address
         treasury = (await signer(1)).address
         nonAdmin = await signer(2)
         collateralTokens = await deployContract<BitDAO>('BitDAO', admin)
-        collateralSymbol = await collateralTokens.symbol()
-        bonds = await deployContractWithProxy<BondFactory>(
-            'BondFactory',
-            collateralTokens.address
-        )
+        bonds = await deployContractWithProxy<BondFactory>('BondFactory')
     })
 
     describe('create bond', () => {
-        it('non-whitelisted collateral', async () => {
-            await expect(
-                bonds.createBond(
-                    {name: 'Named bond', symbol: 'AA00AA'},
-                    {
-                        debtTokens: 101n,
-                        collateralTokenSymbol: 'BEEP',
-                        expiryTimestamp: 0n,
-                        minimumDeposit: 0n,
-                        treasury: treasury,
-                        data: ''
-                    }
-                )
-            ).to.be.revertedWith('BF: collateral not whitelisted')
-        })
-
-        it('whitelisted (BIT) collateral', async () => {
+        it('with BIT token collateral', async () => {
             const bondName = 'Special Debt Certificate'
             const bondSymbol = 'SDC001'
             const debtTokenAmount = 555666777n
-            const collateralSymbol = 'BIT'
             const expiryTimestamp = 560000n
             const minimumDeposit = 100n
             const data = 'a random;delimiter;separated string'
@@ -70,7 +46,7 @@ describe('Bond Factory contract', () => {
                     {name: bondName, symbol: bondSymbol},
                     {
                         debtTokens: debtTokenAmount,
-                        collateralTokenSymbol: collateralSymbol,
+                        collateralTokens: collateralTokens.address,
                         expiryTimestamp: expiryTimestamp,
                         minimumDeposit: minimumDeposit,
                         treasury: treasury,
@@ -101,7 +77,7 @@ describe('Bond Factory contract', () => {
                     {name: 'Named bond', symbol: 'AA00AA'},
                     {
                         debtTokens: 101n,
-                        collateralTokenSymbol: 'BEEP',
+                        collateralTokens: collateralTokens.address,
                         expiryTimestamp: 0n,
                         minimumDeposit: 0n,
                         treasury: treasury,
@@ -109,204 +85,6 @@ describe('Bond Factory contract', () => {
                     }
                 )
             ).to.be.revertedWith('Pausable: paused')
-        })
-    })
-
-    describe('collateral whitelist', () => {
-        before(async () => {
-            await bonds.unpause()
-        })
-        describe('add', () => {
-            it('new token', async () => {
-                const symbol = 'EEK'
-                const tokens = await deployContract<ERC20>(
-                    'ERC20',
-                    'Another erc20 Token',
-                    symbol
-                )
-                expect(await tokens.symbol()).equals(symbol)
-
-                await bonds.whitelistCollateral(tokens.address)
-
-                expect(await bonds.isCollateralWhitelisted(symbol)).is.true
-                expect(await bonds.whitelistedCollateralAddress(symbol)).equals(
-                    tokens.address
-                )
-            })
-
-            it('cannot be an existing token', async () => {
-                await expect(
-                    bonds.whitelistCollateral(collateralTokens.address)
-                ).to.be.revertedWith('Whitelist: already present')
-            })
-
-            it('cannot have address zero', async () => {
-                await expect(
-                    bonds.whitelistCollateral(ADDRESS_ZERO)
-                ).to.be.revertedWith('Whitelist: zero address')
-            })
-
-            it('cannot be a non-erc20 contract (without fallback)', async () => {
-                const box = await deployContract<Box>('Box')
-
-                await expect(
-                    bonds.whitelistCollateral(box.address)
-                ).to.be.revertedWith(
-                    "function selector was not recognized and there's no fallback function"
-                )
-            })
-
-            it('only bond admin', async () => {
-                await expect(
-                    bonds
-                        .connect(nonAdmin)
-                        .whitelistCollateral(collateralTokens.address)
-                ).to.be.revertedWith(
-                    accessControlRevertMessage(nonAdmin, BOND_ADMIN)
-                )
-            })
-
-            it('only when not paused', async () => {
-                await successfulTransaction(bonds.pause())
-                expect(await bonds.paused()).is.true
-                const symbol = 'EEK'
-                const tokens = await deployContract<ERC20>(
-                    'ERC20',
-                    'Another erc20 Token',
-                    symbol
-                )
-                expect(await tokens.symbol()).equals(symbol)
-
-                await expect(
-                    bonds.whitelistCollateral(tokens.address)
-                ).to.be.revertedWith('Pausable: paused')
-            })
-        })
-
-        describe('update', () => {
-            before(async () => {
-                await bonds.unpause()
-            })
-            it('cannot have identical value', async () => {
-                await expect(
-                    bonds.updateWhitelistedCollateral(collateralTokens.address)
-                ).to.be.revertedWith('Whitelist: identical address')
-            })
-
-            it('cannot have address zero', async () => {
-                await expect(
-                    bonds.updateWhitelistedCollateral(ADDRESS_ZERO)
-                ).to.be.revertedWith('Whitelist: zero address')
-            })
-
-            it('cannot be a non-contract address', async () => {
-                await expect(
-                    bonds.updateWhitelistedCollateral(admin)
-                ).to.be.revertedWith('function call to a non-contract account')
-            })
-
-            it('cannot be a non-erc20 contract (without fallback)', async () => {
-                const box = await deployContract<Box>('Box')
-
-                await expect(
-                    bonds.updateWhitelistedCollateral(box.address)
-                ).to.be.revertedWith(
-                    "function selector was not recognized and there's no fallback function"
-                )
-            })
-
-            it('only bond admin', async () => {
-                await expect(
-                    bonds
-                        .connect(nonAdmin)
-                        .updateWhitelistedCollateral(collateralTokens.address)
-                ).to.be.revertedWith(
-                    accessControlRevertMessage(nonAdmin, BOND_ADMIN)
-                )
-            })
-
-            it('existing address', async () => {
-                const startingAddress =
-                    await bonds.whitelistedCollateralAddress(collateralSymbol)
-                expect(startingAddress).equals(collateralTokens.address)
-                const altCollateralTokens = await deployContract<BitDAO>(
-                    'BitDAO',
-                    admin
-                )
-                expect(await altCollateralTokens.symbol()).equals(
-                    collateralSymbol
-                )
-                expect(altCollateralTokens.address).not.equals(startingAddress)
-
-                await bonds.updateWhitelistedCollateral(
-                    altCollateralTokens.address
-                )
-
-                const updatedAddress = await bonds.whitelistedCollateralAddress(
-                    collateralSymbol
-                )
-                expect(updatedAddress).not.equals(startingAddress)
-            })
-
-            it('only when not paused', async () => {
-                await successfulTransaction(bonds.pause())
-                expect(await bonds.paused()).is.true
-                const symbol = 'EEK'
-                const tokens = await deployContract<ERC20>(
-                    'ERC20',
-                    'Another erc20 Token',
-                    symbol
-                )
-                expect(await tokens.symbol()).equals(symbol)
-
-                await expect(
-                    bonds.updateWhitelistedCollateral(tokens.address)
-                ).to.be.revertedWith('Pausable: paused')
-            })
-        })
-
-        describe('remove', () => {
-            before(async () => {
-                await bonds.unpause()
-            })
-            it('entry', async () => {
-                expect(await bonds.isCollateralWhitelisted(collateralSymbol)).is
-                    .true
-
-                await bonds.removeWhitelistedCollateral(collateralSymbol)
-
-                expect(await bonds.isCollateralWhitelisted(collateralSymbol)).is
-                    .false
-            })
-
-            it('non-existent entry', async () => {
-                const absentSymbol = 'A value not in the whitelist'
-                expect(await bonds.isCollateralWhitelisted(absentSymbol)).is
-                    .false
-
-                await expect(
-                    bonds.removeWhitelistedCollateral(absentSymbol)
-                ).to.be.revertedWith('Whitelist: not whitelisted')
-            })
-
-            it('only bond admin', async () => {
-                await expect(
-                    bonds
-                        .connect(nonAdmin)
-                        .removeWhitelistedCollateral(collateralSymbol)
-                ).to.be.revertedWith(
-                    accessControlRevertMessage(nonAdmin, BOND_ADMIN)
-                )
-            })
-
-            it('only when not paused', async () => {
-                await successfulTransaction(bonds.pause())
-                expect(await bonds.paused()).is.true
-                const symbol = 'EEK'
-                await expect(
-                    bonds.removeWhitelistedCollateral(symbol)
-                ).to.be.revertedWith('Pausable: paused')
-            })
         })
     })
 
@@ -341,6 +119,5 @@ describe('Bond Factory contract', () => {
     let treasury: string
     let nonAdmin: SignerWithAddress
     let collateralTokens: ExtendedERC20
-    let collateralSymbol: string
     let bonds: BondFactory
 })

--- a/test/bond-manager.test.ts
+++ b/test/bond-manager.test.ts
@@ -43,11 +43,7 @@ describe('Bond Manager contract', () => {
         treasury = (await signer(3)).address
         curator = await deployContractWithProxy<BondManager>('BondManager')
         collateralTokens = await deployContract<BitDAO>('BitDAO', admin)
-        collateralSymbol = await collateralTokens.symbol()
-        creator = await deployContractWithProxy<BondFactory>(
-            'BondFactory',
-            collateralTokens.address
-        )
+        creator = await deployContractWithProxy<BondFactory>('BondFactory')
     })
 
     describe('add bond', () => {
@@ -431,7 +427,7 @@ describe('Bond Manager contract', () => {
                 {name: 'name', symbol: 'symbol'},
                 {
                     debtTokens: 100n,
-                    collateralTokenSymbol: collateralSymbol,
+                    collateralTokens: collateralTokens.address,
                     expiryTimestamp: 0n,
                     minimumDeposit: 1n,
                     treasury: treasury,
@@ -455,6 +451,5 @@ describe('Bond Manager contract', () => {
     let nonBondAggregator: SignerWithAddress
     let curator: BondManager
     let collateralTokens: ExtendedERC20
-    let collateralSymbol: string
     let creator: BondFactory
 })

--- a/test/bond-manager.test.ts
+++ b/test/bond-manager.test.ts
@@ -426,7 +426,7 @@ describe('Bond Manager contract', () => {
             creator.createBond(
                 {name: 'name', symbol: 'symbol'},
                 {
-                    debtTokens: 100n,
+                    debtTokenAmount: 100n,
                     collateralTokens: collateralTokens.address,
                     expiryTimestamp: 0n,
                     minimumDeposit: 1n,

--- a/test/erc20-single-collateral-bond.test.ts
+++ b/test/erc20-single-collateral-bond.test.ts
@@ -64,10 +64,7 @@ describe('ERC20 Single Collateral Bond contract', () => {
             admin.address
         )) as ExtendedERC20
         collateralSymbol = await collateralTokens.symbol()
-        bonds = await deployContractWithProxy<BondFactory>(
-            'BondFactory',
-            collateralTokens.address
-        )
+        bonds = await deployContractWithProxy<BondFactory>('BondFactory')
     })
 
     describe('allow redemption', () => {
@@ -411,7 +408,7 @@ describe('ERC20 Single Collateral Bond contract', () => {
                     {name: 'Special Debt Certificate', symbol: 'SDC001'},
                     {
                         debtTokens: 500n,
-                        collateralTokenSymbol: collateralSymbol,
+                        collateralTokens: collateralTokens.address,
                         expiryTimestamp: Date.now() + ONE_DAY_MS,
                         minimumDeposit: MINIMUM_DEPOSIT,
                         treasury: treasury,
@@ -1726,7 +1723,7 @@ describe('ERC20 Single Collateral Bond contract', () => {
                 {name: 'Special Debt Certificate', symbol: 'SDC001'},
                 {
                     debtTokens: debtTokens,
-                    collateralTokenSymbol: collateralSymbol,
+                    collateralTokens: collateralTokens.address,
                     expiryTimestamp: BOND_EXPIRY,
                     minimumDeposit: MINIMUM_DEPOSIT,
                     treasury: treasury,

--- a/test/erc20-single-collateral-bond.test.ts
+++ b/test/erc20-single-collateral-bond.test.ts
@@ -407,7 +407,7 @@ describe('ERC20 Single Collateral Bond contract', () => {
                 bonds.createBond(
                     {name: 'Special Debt Certificate', symbol: 'SDC001'},
                     {
-                        debtTokens: 500n,
+                        debtTokenAmount: 500n,
                         collateralTokens: collateralTokens.address,
                         expiryTimestamp: Date.now() + ONE_DAY_MS,
                         minimumDeposit: MINIMUM_DEPOSIT,
@@ -1716,13 +1716,13 @@ describe('ERC20 Single Collateral Bond contract', () => {
 
     async function createBond(
         factory: BondFactory,
-        debtTokens: BigNumberish
+        debtTokenAmount: BigNumberish
     ): Promise<ERC20SingleCollateralBond> {
         const receipt = await execute(
             factory.createBond(
                 {name: 'Special Debt Certificate', symbol: 'SDC001'},
                 {
-                    debtTokens: debtTokens,
+                    debtTokenAmount: debtTokenAmount,
                     collateralTokens: collateralTokens.address,
                     expiryTimestamp: BOND_EXPIRY,
                     minimumDeposit: MINIMUM_DEPOSIT,


### PR DESCRIPTION
### Purpose for this PR
Second part of the refactoring to implement https://github.com/windranger-io/windranger-treasury/issues/161
<!-- Have you included adequate testing for this change? -->

By moving collateral check into the mediator, the factor is now, or can be DAO ID agnostic.