### PR TITLE
feat: granting dao admin roles to creators their daos

### DIFF
--- a/contracts/bond/BondMediator.sol
+++ b/contracts/bond/BondMediator.sol
@@ -48,9 +48,11 @@ contract BondMediator is
     function createDao(address erc20CapableTreasury)
         external
         override
+        atLeastDaoCreatorRole
         returns (uint256)
     {
         uint256 id = _daoBondConfiguration(erc20CapableTreasury);
+        _grantDaoCreatorAdminRoleInTheirDao(id);
 
         emit CreateDao(id, erc20CapableTreasury);
 
@@ -142,4 +144,10 @@ contract BondMediator is
         override
         atLeastSysAdminRole
     {}
+
+    function _grantDaoCreatorAdminRoleInTheirDao(uint256 daoId) private {
+        if (_hasGlobalRole(Roles.DAO_CREATOR, _msgSender())) {
+            _grantDaoRole(daoId, Roles.DAO_ADMIN, _msgSender());
+        }
+    }
 }

--- a/contracts/bond/DaoBondConfiguration.sol
+++ b/contracts/bond/DaoBondConfiguration.sol
@@ -17,6 +17,10 @@ abstract contract DaoBondConfiguration is DaoBondCollateralWhitelist {
         return _daoConfig[daoId].treasury;
     }
 
+    function highestDaoId() external view returns (uint256) {
+        return _daoConfigLastId;
+    }
+
     /**
      * @notice The _msgSender() is given membership of all roles, to allow granting and future renouncing after others
      *      have been setup.


### PR DESCRIPTION
### Purpose for this PR
When a `DAO_CREATOR` creates a DAO, by default they have no access, where in reality they should be a `DAO_ADMIN` for that DAO.

A `SUPER_USER` has no restriction and can do anything, anywhere 🙂 
<!-- Have you included adequate testing for this change? -->
