### PR TITLE
feat: Add bond event

### DIFF
--- a/contracts/bond/BondCurator.sol
+++ b/contracts/bond/BondCurator.sol
@@ -19,6 +19,8 @@ abstract contract BondCurator is RoleAccessControl, PausableUpgradeable {
 
     mapping(uint256 => EnumerableSetUpgradeable.AddressSet) private _bonds;
 
+    event AddBond(uint256 daiId, address bond);
+
     function bondAllowRedemption(
         uint256 daoId,
         address bond,
@@ -127,6 +129,8 @@ abstract contract BondCurator is RoleAccessControl, PausableUpgradeable {
             OwnableUpgradeable(bond).owner() == address(this),
             "BondCurator: not bond owner"
         );
+
+        emit AddBond(daoId, bond);
 
         bool added = _bonds[daoId].add(bond);
         require(added, "BondCurator: failed to add");

--- a/contracts/bond/BondCurator.sol
+++ b/contracts/bond/BondCurator.sol
@@ -130,7 +130,6 @@ abstract contract BondCurator is RoleAccessControl, PausableUpgradeable {
             "BondCurator: not bond owner"
         );
 
-        //slither-disable-next-line reentrancy-events
         emit AddBond(daoId, bond);
 
         bool added = _bonds[daoId].add(bond);

--- a/contracts/bond/BondCurator.sol
+++ b/contracts/bond/BondCurator.sol
@@ -130,6 +130,7 @@ abstract contract BondCurator is RoleAccessControl, PausableUpgradeable {
             "BondCurator: not bond owner"
         );
 
+        //slither-disable-next-line reentrancy-events
         emit AddBond(daoId, bond);
 
         bool added = _bonds[daoId].add(bond);

--- a/contracts/bond/BondMediator.sol
+++ b/contracts/bond/BondMediator.sol
@@ -81,7 +81,11 @@ contract BondMediator is
             configuration,
             _daoTreasury(daoId)
         );
+
+        // Reentrancy warning from an emitted event, which needs the Bond, created by an external call above.
+        //slither-disable-next-line reentrancy-events
         _addBond(daoId, bond);
+
         return bond;
     }
 

--- a/test/contracts/bond/bond-curator-events.ts
+++ b/test/contracts/bond/bond-curator-events.ts
@@ -1,0 +1,42 @@
+import {Event} from 'ethers'
+import {expect} from 'chai'
+import {Result} from '@ethersproject/abi'
+import {AddBondEvent} from '../../../typechain-types/BondCurator'
+
+export type ActualAddBondEvent = {
+    bond: string
+}
+
+/**
+ * Shape check and conversion for a AddBondEvent.
+ */
+export function addBondEvents(events: Event[]): ActualAddBondEvent[] {
+    const bonds: ActualAddBondEvent[] = []
+
+    for (const event of events) {
+        const create = event as AddBondEvent
+        expect(event.args).is.not.undefined
+
+        const args = event.args
+        expect(args?.bond).is.not.undefined
+
+        bonds.push(create.args)
+    }
+
+    return bonds
+}
+
+/**
+ * Shape check and conversion for a event log entry for AddBond.
+ */
+export function addBondEventLogs(events: Result[]): ActualAddBondEvent[] {
+    const results: ActualAddBondEvent[] = []
+
+    for (const event of events) {
+        expect(event?.bond).is.not.undefined
+        expect(event?.bond).to.be.a('string')
+        results.push({bond: String(event.bond)})
+    }
+
+    return results
+}

--- a/test/contracts/bond/verify-curator-events.ts
+++ b/test/contracts/bond/verify-curator-events.ts
@@ -1,0 +1,53 @@
+import {BaseContract, ContractReceipt} from 'ethers'
+import {
+    ActualAddBondEvent,
+    addBondEventLogs,
+    addBondEvents
+} from './bond-curator-events'
+import {eventLog} from '../../framework/event-logs'
+import {verifyOrderedEvents} from '../../framework/verify'
+import {events} from '../../framework/events'
+
+type ExpectedAddBondEvent = {bond: string}
+
+/**
+ * Verifies the content for an Add Bond event.
+ */
+export function verifyAddBondEvents(
+    receipt: ContractReceipt,
+    bonds: ExpectedAddBondEvent[]
+): void {
+    const actualEvents = addBondEvents(events('AddBond', receipt))
+
+    verifyOrderedEvents(
+        actualEvents,
+        bonds,
+        (actual: ActualAddBondEvent, expected: ExpectedAddBondEvent) =>
+            deepEqualsAddBondEvent(actual, expected)
+    )
+}
+
+/**
+ * Verifies the event log entries contain the expected Add Bond events.
+ */
+export function verifyAddBondLogEvents<T extends BaseContract>(
+    emitter: T,
+    receipt: ContractReceipt,
+    bonds: ExpectedAddBondEvent[]
+): void {
+    const actualEvents = addBondEventLogs(eventLog('AddBond', emitter, receipt))
+
+    verifyOrderedEvents(
+        actualEvents,
+        bonds,
+        (actual: ActualAddBondEvent, expected: ExpectedAddBondEvent) =>
+            deepEqualsAddBondEvent(actual, expected)
+    )
+}
+
+function deepEqualsAddBondEvent(
+    actual: ActualAddBondEvent,
+    expected: ExpectedAddBondEvent
+): boolean {
+    return actual.bond === expected.bond
+}


### PR DESCRIPTION
### Purpose for this PR
Adding back the event that outputs the bond address and dao Id that it belongs to.
<!-- Have you included adequate testing for this change? -->
