### PR TITLE
fix: timestamps to uint128 on StakingPool contracts

### DIFF
--- a/contracts/staking/StakingPool.sol
+++ b/contracts/staking/StakingPool.sol
@@ -40,7 +40,7 @@ contract StakingPool is
 
     mapping(address => User) private _users;
 
-    uint32 private _rewardsAvailableTimestamp;
+    uint128 private _rewardsAvailableTimestamp;
     bool private _emergencyMode;
     uint128 private _totalStakedAmount;
 
@@ -54,7 +54,7 @@ contract StakingPool is
     event WithdrawStake(address indexed user, uint256 stake);
     event Deposit(address indexed user, uint256 depositAmount);
     event InitializeRewards(address rewardTokens, uint256 amount);
-    event RewardsAvailableTimestamp(uint32 rewardsAvailableTimestamp);
+    event RewardsAvailableTimestamp(uint128 rewardsAvailableTimestamp);
     event EmergencyMode(address indexed admin);
     event NoRewards(address indexed user);
 
@@ -231,7 +231,7 @@ contract StakingPool is
     function initialize(
         StakingPoolLib.Config calldata info,
         bool paused,
-        uint32 rewardsTimestamp
+        uint128 rewardsTimestamp
     ) external virtual initializer {
         __RoleAccessControl_init();
         __Context_init_unchained();
@@ -291,7 +291,7 @@ contract StakingPool is
         _adminEmergencyRewardSweep();
     }
 
-    function setRewardsAvailableTimestamp(uint32 timestamp)
+    function setRewardsAvailableTimestamp(uint128 timestamp)
         external
         atLeastDaoAdminRole(_stakingPoolConfig.daoId)
     {
@@ -322,7 +322,7 @@ contract StakingPool is
         return _stakingPoolConfig;
     }
 
-    function rewardsAvailableTimestamp() external view returns (uint32) {
+    function rewardsAvailableTimestamp() external view returns (uint128) {
         return _rewardsAvailableTimestamp;
     }
 
@@ -421,7 +421,7 @@ contract StakingPool is
         _transferStake(uint256((user.depositAmount)), _config.stakeToken);
     }
 
-    function _setRewardsAvailableTimestamp(uint32 timestamp) internal {
+    function _setRewardsAvailableTimestamp(uint128 timestamp) internal {
         require(!_isStakingPeriodComplete(), "StakePool: already finalized");
         //slither-disable-next-line timestamp
         require(timestamp > block.timestamp, "StakePool: future rewards");

--- a/contracts/staking/StakingPoolFactory.sol
+++ b/contracts/staking/StakingPoolFactory.sol
@@ -33,7 +33,7 @@ contract StakingPoolFactory is RoleAccessControl, PausableUpgradeable, Version {
     function createStakingPool(
         StakingPoolLib.Config calldata config,
         bool launchPaused,
-        uint32 rewardsAvailableTimestamp
+        uint128 rewardsAvailableTimestamp
     )
         external
         whenNotPaused

--- a/contracts/staking/StakingPoolLib.sol
+++ b/contracts/staking/StakingPoolLib.sol
@@ -20,8 +20,8 @@ library StakingPoolLib {
         uint128 minTotalPoolStake;
         uint128 maxTotalPoolStake;
         uint128 minimumContribution;
-        uint32 epochDuration;
-        uint32 epochStartTimestamp;
+        uint128 epochDuration;
+        uint128 epochStartTimestamp;
         address treasury;
         IERC20 stakeToken;
         Reward[] rewardTokens;


### PR DESCRIPTION
### Purpose for this PR

Sets type to uint128 for timestamp values

