### PR TITLE
fix: auto generation of natspec markdown from Solidity files

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -92,3 +92,6 @@ doc/
 # Yarn lock file (npm.lock covers this)
 yarn.lock
 yarn-error.log
+
+# Custom location for the generated Solidity NatSpec docs
+solidity-docs/

--- a/README.md
+++ b/README.md
@@ -175,3 +175,13 @@ The size of all contract can be display in a table using a custom task that runs
 ```shell
 yarn run hardhat size-contracts
 ```
+
+### Solidity Documentation Generation
+
+Markdown files can be generated from the Solidity files
+
+```shell
+npx hardhat docgen
+```
+
+The output mirrors the Solidity file structure and will be found at `./solidity-docs`.

--- a/hardhat.config.ts
+++ b/hardhat.config.ts
@@ -4,6 +4,7 @@ import '@nomiclabs/hardhat-etherscan'
 import '@nomiclabs/hardhat-waffle'
 import '@openzeppelin/hardhat-upgrades'
 import 'hardhat-contract-sizer'
+import 'solidity-docgen'
 import {task} from 'hardhat/config'
 import {log} from './config/logging'
 
@@ -75,5 +76,6 @@ export default {
         alphaSort: true,
         runOnCompile: false,
         disambiguatePaths: false
-    }
+    },
+    docgen: {outputDir: 'solidity-docs', pages: 'files'}
 }

--- a/package-lock.json
+++ b/package-lock.json
@@ -44,6 +44,7 @@
         "prettier": "2.6.2",
         "prettier-plugin-solidity": "^1.0.0-beta.19",
         "solhint": "3.3.7",
+        "solidity-docgen": "^0.6.0-beta.16",
         "ts-node": "10.8.0",
         "typechain": "8.0.0",
         "typescript": "4.7.2"
@@ -13793,6 +13794,27 @@
         "node": ">=4.x"
       }
     },
+    "node_modules/handlebars": {
+      "version": "4.7.7",
+      "resolved": "https://registry.npmjs.org/handlebars/-/handlebars-4.7.7.tgz",
+      "integrity": "sha512-aAcXm5OAfE/8IXkcZvCepKU3VzW1/39Fb5ZuqMtgI/hT8X2YgoMvBY5dLhq/cpOvw7Lk1nK/UF71aLG/ZnVYRA==",
+      "dev": true,
+      "dependencies": {
+        "minimist": "^1.2.5",
+        "neo-async": "^2.6.0",
+        "source-map": "^0.6.1",
+        "wordwrap": "^1.0.0"
+      },
+      "bin": {
+        "handlebars": "bin/handlebars"
+      },
+      "engines": {
+        "node": ">=0.4.7"
+      },
+      "optionalDependencies": {
+        "uglify-js": "^3.1.4"
+      }
+    },
     "node_modules/har-schema": {
       "version": "2.0.0",
       "resolved": "https://registry.npmjs.org/har-schema/-/har-schema-2.0.0.tgz",
@@ -15863,6 +15885,12 @@
         "ncp": "bin/ncp"
       }
     },
+    "node_modules/neo-async": {
+      "version": "2.6.2",
+      "resolved": "https://registry.npmjs.org/neo-async/-/neo-async-2.6.2.tgz",
+      "integrity": "sha512-Yd3UES5mWCSqR+qNT93S3UoYUkqAZ9lLg8a7g9rimsWmYGK8cVToA4/sF3RrshdyV3sAGMXVUmpMYOw+dLpOuw==",
+      "dev": true
+    },
     "node_modules/nice-try": {
       "version": "1.0.5",
       "resolved": "https://registry.npmjs.org/nice-try/-/nice-try-1.0.5.tgz",
@@ -17860,9 +17888,9 @@
       }
     },
     "node_modules/solidity-ast": {
-      "version": "0.4.30",
-      "resolved": "https://registry.npmjs.org/solidity-ast/-/solidity-ast-0.4.30.tgz",
-      "integrity": "sha512-3xsQIbZEPx6w7+sQokuOvk1RkMb5GIpuK0GblQDIH6IAkU4+uyJQVJIRNP+8KwhzkViwRKq0hS4zLqQNLKpxOA==",
+      "version": "0.4.32",
+      "resolved": "https://registry.npmjs.org/solidity-ast/-/solidity-ast-0.4.32.tgz",
+      "integrity": "sha512-vCx17410X+NMnpLVyg6ix4NMCHFIkvWrJb1rPBBeQYEQChX93Zgb9WB9NaIY4zpsr3Q8IvAfohw+jmuBzGf8OQ==",
       "dev": true
     },
     "node_modules/solidity-comments-extractor": {
@@ -17870,6 +17898,19 @@
       "resolved": "https://registry.npmjs.org/solidity-comments-extractor/-/solidity-comments-extractor-0.0.7.tgz",
       "integrity": "sha512-wciNMLg/Irp8OKGrh3S2tfvZiZ0NEyILfcRCXCD4mp7SgK/i9gzLfhY2hY7VMCQJ3kH9UB9BzNdibIVMchzyYw==",
       "dev": true
+    },
+    "node_modules/solidity-docgen": {
+      "version": "0.6.0-beta.16",
+      "resolved": "https://registry.npmjs.org/solidity-docgen/-/solidity-docgen-0.6.0-beta.16.tgz",
+      "integrity": "sha512-FD7aUWdbtkXW41T/4K+iNXrf7ab+OmAXulDOoD0aTonz76d4wmmFLSrAfoAIo0wm9nDyYiZ1Sw1KZ89Z8sAfEQ==",
+      "dev": true,
+      "dependencies": {
+        "handlebars": "^4.7.7",
+        "solidity-ast": "^0.4.31"
+      },
+      "peerDependencies": {
+        "hardhat": "^2.8.0"
+      }
     },
     "node_modules/source-map": {
       "version": "0.6.1",
@@ -18753,6 +18794,19 @@
       "integrity": "sha1-XAgOXWYcu+OCWdLnCjxyU+hziB0=",
       "dev": true
     },
+    "node_modules/uglify-js": {
+      "version": "3.16.0",
+      "resolved": "https://registry.npmjs.org/uglify-js/-/uglify-js-3.16.0.tgz",
+      "integrity": "sha512-FEikl6bR30n0T3amyBh3LoiBdqHRy/f4H80+My34HOesOKyHfOsxAPAxOoqC0JUnC1amnO0IwkYC3sko51caSw==",
+      "dev": true,
+      "optional": true,
+      "bin": {
+        "uglifyjs": "bin/uglifyjs"
+      },
+      "engines": {
+        "node": ">=0.8.0"
+      }
+    },
     "node_modules/undici": {
       "version": "4.15.0",
       "resolved": "https://registry.npmjs.org/undici/-/undici-4.15.0.tgz",
@@ -18931,6 +18985,12 @@
       "engines": {
         "node": ">=0.10.0"
       }
+    },
+    "node_modules/wordwrap": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/wordwrap/-/wordwrap-1.0.0.tgz",
+      "integrity": "sha1-J1hIEIkUVqQXHI0CJkQa3pDLyus=",
+      "dev": true
     },
     "node_modules/wordwrapjs": {
       "version": "4.0.1",
@@ -29673,6 +29733,19 @@
       "resolved": "https://registry.npmjs.org/growl/-/growl-1.10.5.tgz",
       "integrity": "sha512-qBr4OuELkhPenW6goKVXiv47US3clb3/IbuWF9KNKEijAy9oeHxU9IgzjvJhHkUzhaj7rOUD7+YGWqUjLp5oSA=="
     },
+    "handlebars": {
+      "version": "4.7.7",
+      "resolved": "https://registry.npmjs.org/handlebars/-/handlebars-4.7.7.tgz",
+      "integrity": "sha512-aAcXm5OAfE/8IXkcZvCepKU3VzW1/39Fb5ZuqMtgI/hT8X2YgoMvBY5dLhq/cpOvw7Lk1nK/UF71aLG/ZnVYRA==",
+      "dev": true,
+      "requires": {
+        "minimist": "^1.2.5",
+        "neo-async": "^2.6.0",
+        "source-map": "^0.6.1",
+        "uglify-js": "^3.1.4",
+        "wordwrap": "^1.0.0"
+      }
+    },
     "har-schema": {
       "version": "2.0.0",
       "resolved": "https://registry.npmjs.org/har-schema/-/har-schema-2.0.0.tgz",
@@ -31253,6 +31326,12 @@
       "integrity": "sha1-GVoh1sRuNh0vsSgbo4uR6d9727M=",
       "optional": true
     },
+    "neo-async": {
+      "version": "2.6.2",
+      "resolved": "https://registry.npmjs.org/neo-async/-/neo-async-2.6.2.tgz",
+      "integrity": "sha512-Yd3UES5mWCSqR+qNT93S3UoYUkqAZ9lLg8a7g9rimsWmYGK8cVToA4/sF3RrshdyV3sAGMXVUmpMYOw+dLpOuw==",
+      "dev": true
+    },
     "nice-try": {
       "version": "1.0.5",
       "resolved": "https://registry.npmjs.org/nice-try/-/nice-try-1.0.5.tgz",
@@ -32762,9 +32841,9 @@
       }
     },
     "solidity-ast": {
-      "version": "0.4.30",
-      "resolved": "https://registry.npmjs.org/solidity-ast/-/solidity-ast-0.4.30.tgz",
-      "integrity": "sha512-3xsQIbZEPx6w7+sQokuOvk1RkMb5GIpuK0GblQDIH6IAkU4+uyJQVJIRNP+8KwhzkViwRKq0hS4zLqQNLKpxOA==",
+      "version": "0.4.32",
+      "resolved": "https://registry.npmjs.org/solidity-ast/-/solidity-ast-0.4.32.tgz",
+      "integrity": "sha512-vCx17410X+NMnpLVyg6ix4NMCHFIkvWrJb1rPBBeQYEQChX93Zgb9WB9NaIY4zpsr3Q8IvAfohw+jmuBzGf8OQ==",
       "dev": true
     },
     "solidity-comments-extractor": {
@@ -32772,6 +32851,16 @@
       "resolved": "https://registry.npmjs.org/solidity-comments-extractor/-/solidity-comments-extractor-0.0.7.tgz",
       "integrity": "sha512-wciNMLg/Irp8OKGrh3S2tfvZiZ0NEyILfcRCXCD4mp7SgK/i9gzLfhY2hY7VMCQJ3kH9UB9BzNdibIVMchzyYw==",
       "dev": true
+    },
+    "solidity-docgen": {
+      "version": "0.6.0-beta.16",
+      "resolved": "https://registry.npmjs.org/solidity-docgen/-/solidity-docgen-0.6.0-beta.16.tgz",
+      "integrity": "sha512-FD7aUWdbtkXW41T/4K+iNXrf7ab+OmAXulDOoD0aTonz76d4wmmFLSrAfoAIo0wm9nDyYiZ1Sw1KZ89Z8sAfEQ==",
+      "dev": true,
+      "requires": {
+        "handlebars": "^4.7.7",
+        "solidity-ast": "^0.4.31"
+      }
     },
     "source-map": {
       "version": "0.6.1",
@@ -33450,6 +33539,13 @@
       "integrity": "sha1-XAgOXWYcu+OCWdLnCjxyU+hziB0=",
       "dev": true
     },
+    "uglify-js": {
+      "version": "3.16.0",
+      "resolved": "https://registry.npmjs.org/uglify-js/-/uglify-js-3.16.0.tgz",
+      "integrity": "sha512-FEikl6bR30n0T3amyBh3LoiBdqHRy/f4H80+My34HOesOKyHfOsxAPAxOoqC0JUnC1amnO0IwkYC3sko51caSw==",
+      "dev": true,
+      "optional": true
+    },
     "undici": {
       "version": "4.15.0",
       "resolved": "https://registry.npmjs.org/undici/-/undici-4.15.0.tgz",
@@ -33596,6 +33692,12 @@
       "version": "1.2.3",
       "resolved": "https://registry.npmjs.org/word-wrap/-/word-wrap-1.2.3.tgz",
       "integrity": "sha512-Hz/mrNwitNRh/HUAtM/VT/5VH+ygD6DV7mYKZAtHOrbs8U7lvPS6xf7EJKMF0uW1KJCl0H701g3ZGus+muE5vQ==",
+      "dev": true
+    },
+    "wordwrap": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/wordwrap/-/wordwrap-1.0.0.tgz",
+      "integrity": "sha1-J1hIEIkUVqQXHI0CJkQa3pDLyus=",
       "dev": true
     },
     "wordwrapjs": {

--- a/package.json
+++ b/package.json
@@ -59,6 +59,7 @@
     "prettier-plugin-solidity": "^1.0.0-beta.19",
     "solhint": "3.3.7",
     "ts-node": "10.8.0",
+    "solidity-docgen": "^0.6.0-beta.16",
     "typechain": "8.0.0",
     "typescript": "4.7.2"
   },


### PR DESCRIPTION
### Purpose for this PR
Follows on from https://github.com/windranger-io/windranger-treasury/pull/325

Instead of checking the auto gen docs in, this PR creates a target that the developer can run locally (where the generated directory is excluded via gitignore)
<!-- Have you included adequate testing for this change? -->
