### PR TITLE
replacing quadratic check with linear

### DIFF
--- a/contracts/staking/StakingPool.sol
+++ b/contracts/staking/StakingPool.sol
@@ -41,6 +41,7 @@ contract StakingPool is
     }
 
     mapping(address => User) private _users;
+    mapping(address => bool) private _tokensCounter;
 
     uint32 private _rewardsAvailableTimestamp;
     bool private _emergencyMode;
@@ -483,7 +484,7 @@ contract StakingPool is
         StakingPoolLib.Config memory _config,
         User memory _user,
         uint256 rewardIndex
-    ) internal view returns (uint256) {
+    ) internal pure returns (uint256) {
         if (_config.rewardType == StakingPoolLib.RewardType.FIXED) {
             return _user.rewardAmounts[rewardIndex];
         }
@@ -591,17 +592,16 @@ contract StakingPool is
      */
     function _enforceUniqueRewardTokens(
         StakingPoolLib.Reward[] calldata rewardPools
-    ) private pure {
+    ) private {
         for (uint256 i = 0; i < rewardPools.length; i++) {
-            // Ensure no later entries contain the same tokens address
-            uint256 next = i + 1;
-            if (next < rewardPools.length) {
-                for (uint256 j = next; j < rewardPools.length; j++) {
-                    if (rewardPools[i].tokens == rewardPools[j].tokens) {
-                        revert("Rewards: tokens must be unique");
-                    }
-                }
-            }
+            // Ensure no prev entries contain the same tokens address
+            if (_tokensCounter[address(rewardPools[i].tokens)]) {
+                        revert("StakePool: tokens must be unique");
+            } 
+            _tokensCounter[address(rewardPools[i].tokens)] = true;
+        }
+        for (uint256 i = 0; i < rewardPools.length; i++) {
+            delete _tokensCounter[address(rewardPools[i].tokens)];
         }
     }
 }

--- a/test/contracts/bond/time-lock-multi-reward-bond.test.ts
+++ b/test/contracts/bond/time-lock-multi-reward-bond.test.ts
@@ -285,6 +285,17 @@ describe('TimeLockMultiRewardBond contract', () => {
         })
     })
 
+    it('cannot init with duplicated tokens', async () => {
+        bond = await deployContract<TimeLockMultiRewardBondBox>(
+            'TimeLockMultiRewardBondBox'
+        )
+        const rewardPoolsDuplicated = [...rewardPools]
+        rewardPoolsDuplicated.push(rewardPools[1])
+        await expect(bond.initialize(rewardPoolsDuplicated)).to.be.revertedWith(
+            'Rewards: tokens must be unique'
+        )
+    })
+
     it('init registers reward pools', async () => {
         bond = await deployContract<TimeLockMultiRewardBondBox>(
             'TimeLockMultiRewardBondBox'

--- a/test/contracts/staking/staking.test.ts
+++ b/test/contracts/staking/staking.test.ts
@@ -167,21 +167,22 @@ describe('Staking Pool Tests', () => {
             ).to.be.revertedWith('StakingPool: invalid allowance')
         })
         it('initialize rewards fails duplicated token', async () => {
+            await rewardToken1.mint(admin, amount)
+            await rewardToken1.increaseAllowance(stakingPool.address, amount)
             await expect(
                 stakingPool.initializeRewardTokens(admin, [
                     {
                         tokens: rewardToken1.address,
-                        maxAmount: amount,
+                        maxAmount: 0,
                         ratio: 0
                     },
                     {
                         tokens: rewardToken1.address,
-                        maxAmount: amount,
+                        maxAmount: 0,
                         ratio: 0
                     }
-
                 ])
-            ).to.be.revertedWith('StakingPool: invalid allowance')
+            ).to.be.revertedWith('StakePool: tokens must be unique')
         })
         it('initialize rewards', async () => {
             await rewardToken1.mint(admin, amount)


### PR DESCRIPTION
### Purpose for this PR

Close ticket #330, replacing the quadratic check of duplicated tokens for rewards with a linear check. Is minor but might appear on future audits.

It was passing all the tests and I added 1 more test for each contract I changed.